### PR TITLE
Set a single scope to all tokens in variable-sized delimiters

### DIFF
--- a/syntaxes/TeX.tmLanguage.json
+++ b/syntaxes/TeX.tmLanguage.json
@@ -163,6 +163,14 @@
           ]
         },
         {
+          "match": "\\\\{|\\\\}",
+          "name": "punctuation.math.bracket.pair.tex"
+        },
+        {
+          "match": "\\\\(left|right|((big|bigg|Big|Bigg)[lr]?))([\\(\\[\\<\\>\\]\\)\\.]|\\\\{|\\\\})",
+          "name": "punctuation.math.bracket.pair.big.tex"
+        },
+        {
           "captures": {
             "1": {
               "name": "punctuation.definition.constant.math.tex"
@@ -247,11 +255,11 @@
           "name": "punctuation.math.end.bracket.curly.tex"
         },
         {
-          "match": "\\(",
+          "match": "(?<!\\\\)\\(",
           "name": "punctuation.math.begin.bracket.round.tex"
         },
         {
-          "match": "\\)",
+          "match": "(?<!\\\\)\\)",
           "name": "punctuation.math.end.bracket.round.tex"
         },
         {


### PR DESCRIPTION
This PR assigns the same scope to all tokens of variable-sized delimiters . It solves the non bracket pair colouring of variable-sized delimiters. In particular see https://github.com/microsoft/vscode/issues/137774#issuecomment-986603156

@ZhangSongyi Could you test this PR?

Close #6 