### PR TITLE
Allowed julia syntax highlighting in environments used by pythontex for Julia

### DIFF
--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -463,7 +463,7 @@
 			"end": "(\\\\end\\{\\2\\}(?:\\s*\\n)?)"
 		},
 		{
-			"begin": "((?:\\s*)\\\\begin\\{((?:julia|jl)code(?:\\*)?)\\}(?:\\[.*\\])?)",
+			"begin": "((?:\\s*)\\\\begin\\{((?:julia|jl)(?:code|verbatim|block|concode|console|converbatim)(?:\\*)?)\\}(?:\\[.*\\])?)",
 			"captures": {
 				"1": {
 					"patterns": [


### PR DESCRIPTION
Added some more supported environments such as juliaconsole, juliaverbatim, jlcode etc to have syntax highlighting.

This links to https://github.com/jlelong/vscode-latex-basics/issues/14

Result Before:
![image](https://user-images.githubusercontent.com/13971435/149622147-78109813-8d8a-426d-b20d-788a9f5435f6.png)
Result After:
![image](https://user-images.githubusercontent.com/13971435/149622127-6751b357-f029-4b81-b861-e1b7ffd77081.png)
