### PR TITLE
Update language configuration

### DIFF
--- a/languages/latex-language-configuration.json
+++ b/languages/latex-language-configuration.json
@@ -91,7 +91,8 @@
 		["{", "}"],
 		["[", "]"],
 		["(", ")"],
-		["`", "'"]
+		["`", "'"],
+		["$", "$"]
 	],
 	"surroundingPairs": [
 		["{", "}"],
@@ -106,6 +107,6 @@
 		"increaseIndentPattern": "\\\\begin{(?!document)([^}]*)}(?!.*\\\\end{\\1})",
 		"decreaseIndentPattern": "^\\s*\\\\end{(?!document)"
 	},
-	"autoCloseBefore": ";:.,=}])>\\` \n\t$",
+	"autoCloseBefore": ";:.,={}])>\\` \n\t$",
 	"wordPattern": "([^\\s`'\"~_!?|$#@%^&*\\-=+;:,.<>(){}[\\]\\/]+)"
 }


### PR DESCRIPTION
I propose the following two small changes:

- make `$...$` auto closing. IMHO, this is not something, that users should be actively discouraged from using (in contrast to `$$...$$`).
- add `{` to `autoclosebefore`. This is useful for adding optional parameters to already existing code, in particular for adding parameters to `\usepackage{...}`

Cheers and keep up the good work!