### PR TITLE
Highlight with label optional arguments

### DIFF
--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1901,7 +1901,7 @@
 			"match": "(?:\\s*)((\\\\)(?:begin|end))(\\{)([a-z]+(?:\\*)?)(\\})(?:(\\[).*(\\]))?"
 		},
 		"definition-label": {
-			"begin": "((\\\\)label)(\\{)",
+			"begin": "((\\\\)label)((?:\\[[^\\[]*?\\])*)(\\{)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.label.latex"
@@ -1910,6 +1910,13 @@
 					"name": "punctuation.definition.keyword.latex"
 				},
 				"3": {
+					"patterns": [
+						{
+							"include": "#optional-arg"
+						}
+					]
+				},
+				"4": {
 					"name": "punctuation.definition.arguments.begin.latex"
 				}
 			},


### PR DESCRIPTION
As discussed [here](https://github.com/James-Yu/LaTeX-Workshop/pull/3204#issuecomment-1072263917), creating a new PR so that labels with optional parameters are recognised and highlighted accordingly.