### PR TITLE
Accept usepackage or documentclass split over several lines

### DIFF
--- a/build/generate-grammar-blocks.js
+++ b/build/generate-grammar-blocks.js
@@ -121,7 +121,7 @@ function generateMintedBlock(envName, language, source, contentName=undefined) {
 }
 
 function main() {
-
+    console.log('Generating LaTeX.tmLanguage from data/')
     var mintedDefinitions = mintedLanguages.map(language => generateMintedBlock(language.name, language.language, language.source, language?.contentName)).join(',\n')
     var codeDefinitions = codeLanguages.map(language => generateCodeBlock(language.name, language.source, language?.contentName)).join(',\n')
 
@@ -133,4 +133,3 @@ function main() {
 
 
 module.exports = main
-main()

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1825,13 +1825,13 @@
 				{
 					"captures": {
 						"1": {
-							"name": "punctuation.definition.optional.arguments.begin.latex"
+							"name": "punctuation.definition.arguments.optional.begin.latex"
 						},
 						"2": {
 							"name": "variable.parameter.function.latex"
 						},
 						"3": {
-							"name": "punctuation.definition.optional.arguments.end.latex"
+							"name": "punctuation.definition.arguments.optional.end.latex"
 						}
 					},
 					"match": "(\\[)([^\\[]*?)(\\])",

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -7,27 +7,16 @@
 			"name": "meta.space-after-command.latex"
 		},
 		{
-			"begin": "((\\\\)(?:usepackage|documentclass))((?:\\[[^\\[]*?\\])*)(\\{)",
+			"begin": "((\\\\)(?:usepackage|documentclass))\\b(?=\\[|\\{)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.preamble.latex"
 				},
 				"2": {
 					"name": "punctuation.definition.function.latex"
-				},
-				"3": {
-					"patterns": [
-						{
-							"include": "#optional-arg"
-						}
-					]
-				},
-				"4": {
-					"name": "punctuation.definition.arguments.begin.latex"
 				}
 			},
-			"contentName": "support.class.latex",
-			"end": "\\}",
+			"end": "(?<=\\})",
 			"endCaptures": {
 				"0": {
 					"name": "punctuation.definition.arguments.end.latex"
@@ -36,7 +25,45 @@
 			"name": "meta.preamble.latex",
 			"patterns": [
 				{
-					"include": "$self"
+					"begin": "(\\G\\[)",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.optional.begin.latex"
+						}
+					},
+					"end": "(\\])",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.optional.end.latex"
+						}
+					},
+					"contentName": "variable.parameter.function.latex",
+					"name": "meta.parameter.optional.latex",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"begin": "((?:\\G|(?<=\\]))\\{)",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.begin.latex"
+						}
+					},
+					"end": "(\\})",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.end.latex"
+						}
+					},
+					"contentName": "support.class.latex",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
 				}
 			]
 		},

--- a/syntaxes/data/LaTeX.tmLanguage.json
+++ b/syntaxes/data/LaTeX.tmLanguage.json
@@ -7,27 +7,16 @@
 			"name": "meta.space-after-command.latex"
 		},
 		{
-			"begin": "((\\\\)(?:usepackage|documentclass))((?:\\[[^\\[]*?\\])*)(\\{)",
+			"begin": "((\\\\)(?:usepackage|documentclass))\\b(?=\\[|\\{)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.preamble.latex"
 				},
 				"2": {
 					"name": "punctuation.definition.function.latex"
-				},
-				"3": {
-					"patterns": [
-						{
-							"include": "#optional-arg"
-						}
-					]
-				},
-				"4": {
-					"name": "punctuation.definition.arguments.begin.latex"
 				}
 			},
-			"contentName": "support.class.latex",
-			"end": "\\}",
+			"end": "(?<=\\})",
 			"endCaptures": {
 				"0": {
 					"name": "punctuation.definition.arguments.end.latex"
@@ -36,7 +25,45 @@
 			"name": "meta.preamble.latex",
 			"patterns": [
 				{
-					"include": "$self"
+					"begin": "(\\G\\[)",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.optional.begin.latex"
+						}
+					},
+					"end": "(\\])",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.optional.end.latex"
+						}
+					},
+					"contentName": "variable.parameter.function.latex",
+					"name": "meta.parameter.optional.latex",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"begin": "((?:\\G|(?<=\\]))\\{)",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.begin.latex"
+						}
+					},
+					"end": "(\\})",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.arguments.end.latex"
+						}
+					},
+					"contentName": "support.class.latex",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
 				}
 			]
 		},

--- a/syntaxes/data/LaTeX.tmLanguage.json
+++ b/syntaxes/data/LaTeX.tmLanguage.json
@@ -1295,13 +1295,13 @@
 				{
 					"captures": {
 						"1": {
-							"name": "punctuation.definition.optional.arguments.begin.latex"
+							"name": "punctuation.definition.arguments.optional.begin.latex"
 						},
 						"2": {
 							"name": "variable.parameter.function.latex"
 						},
 						"3": {
-							"name": "punctuation.definition.optional.arguments.end.latex"
+							"name": "punctuation.definition.arguments.optional.end.latex"
 						}
 					},
 					"match": "(\\[)([^\\[]*?)(\\])",

--- a/test/colorize-results/basic-commands_tex.json
+++ b/test/colorize-results/basic-commands_tex.json
@@ -145,7 +145,7 @@
 	},
 	{
 		"c": "[",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.begin.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -169,7 +169,7 @@
 	},
 	{
 		"c": "]",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.end.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1381,7 +1381,7 @@
 	},
 	{
 		"c": "[",
-		"t": "text.tex.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.begin.latex",
+		"t": "text.tex.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1405,7 +1405,7 @@
 	},
 	{
 		"c": "]",
-		"t": "text.tex.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.end.latex",
+		"t": "text.tex.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/test/colorize-results/basic-envs_tex.json
+++ b/test/colorize-results/basic-envs_tex.json
@@ -145,7 +145,7 @@
 	},
 	{
 		"c": "[",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.begin.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -169,7 +169,7 @@
 	},
 	{
 		"c": "]",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.end.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/test/colorize-results/beamer_tex.json
+++ b/test/colorize-results/beamer_tex.json
@@ -25,7 +25,7 @@
 	},
 	{
 		"c": "[",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.begin.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -49,7 +49,7 @@
 	},
 	{
 		"c": "]",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.end.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/test/colorize-results/math-envs_tex.json
+++ b/test/colorize-results/math-envs_tex.json
@@ -145,7 +145,7 @@
 	},
 	{
 		"c": "[",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.begin.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -169,7 +169,7 @@
 	},
 	{
 		"c": "]",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.end.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/test/colorize-results/maths-inline_tex.json
+++ b/test/colorize-results/maths-inline_tex.json
@@ -145,7 +145,7 @@
 	},
 	{
 		"c": "[",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.begin.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -169,7 +169,7 @@
 	},
 	{
 		"c": "]",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.end.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/test/colorize-results/minted_tex.json
+++ b/test/colorize-results/minted_tex.json
@@ -145,7 +145,7 @@
 	},
 	{
 		"c": "[",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.begin.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -169,7 +169,7 @@
 	},
 	{
 		"c": "]",
-		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.optional.arguments.end.latex",
+		"t": "text.tex.latex meta.preamble.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",


### PR DESCRIPTION
Fix #36

With this PR, the following constructions are properly highlighted

```latex
\documentclass[
  a4paper
]{article}


\usepackage[
  atoto, %toto
  font={\small }
]{amsmath, a4apper}

\usepackage{
  aaa,
  bbb
}
```

Inserting a linebreak before the opening brace or bracket is not accepted.

As a by-product, the sub-scope `optional.arguments` is renamed to `arguments.optional` to honor scope precedence.