### PR TITLE
Update `\if...`- and csname-related TeX primitives

### DIFF
--- a/syntaxes/TeX.tmLanguage.json
+++ b/syntaxes/TeX.tmLanguage.json
@@ -7,7 +7,7 @@
 					"name": "punctuation.definition.keyword.tex"
 				}
 			},
-			"match": "(\\\\)(backmatter|else|fi|frontmatter|mainmatter|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?)(?![a-zA-Z@])",
+			"match": "(\\\\)(backmatter|csname|else|endcsname|fi|frontmatter|mainmatter|unless|if(case|cat|csname|defined|dim|eof|false|fontchar|hbox|hmode|inner|mmode|num|odd|true|vbox|vmode|void|x)?)(?![a-zA-Z@])",
 			"name": "keyword.control.tex"
 		},
 		{


### PR DESCRIPTION
1. Add eTeX primitives `\ifcsname`, `\ifdefined`, `\iffontchar`, and `\unless`.
2. Add Knuth TeX primitives `\csname` and `\endcsname`
3. Remove non-existent primitive `\ifundefined` (to verify, just search for "latex \\ifundefined")

In this midnight I just can't live with this inconsistent highlighting anymore so ... .

**Example input**
Yes the (la)tex syntax used by github is imperfect too, but that's not the cause for latex-workshop to not do a better job.
```tex
% source: The eTeX manual, sec. 3.4 _Status Enquiries_ (texdoc etex)
1: \if      8: \ifmmode 15: \iftrue
2: \ifcat   9: \ifinner 16: \iffalse
3: \ifnum   10: \ifvoid 17: \ifcase
4: \ifdim   11: \ifhbox 18: \ifdefined
5: \ifodd   12: \ifvbox 19: \ifcsname
6: \ifvmode 13: \ifx    20: \iffontchar
7: \ifhmode 14: \ifeof

% ltdefns.dtx
\def\@namedef#1{\expandafter\def\csname #1\endcsname}

% ltdefns.dtx
\def\@ifundefined#1{%
  \ifcsname#1\endcsname\@ifundefin@d@i\else\@ifundefin@d@ii\fi{#1}}

% latex2e kernel, ltlatex.dtx
\begingroup
  % ...
  \def\parseunicodedataV#1;#2\relax{%
    \loop
      \unless\ifnum\count0>"#1 %
        \catcode\count0=11 %
        \advance\count0 by 1 %
    \repeat
  }%
  % ...
\endgroup
```
- Current
   <img width="789" alt="image" src="https://user-images.githubusercontent.com/6376638/215869630-125a2756-1f5e-40b3-a6d2-23cdd8c638ac.png">
- Expected: All the 20 `\if...`- and csname-related primitives highlighted in the same color, so `\ifnum ... \else ... \fi` and `\ifcsname ... \else ... \fi` will be similarly colored.

