### PR TITLE
Support non-Latin macro names

### DIFF
--- a/syntaxes/TeX.tmLanguage.json
+++ b/syntaxes/TeX.tmLanguage.json
@@ -110,7 +110,7 @@
 					"name": "punctuation.definition.function.tex"
 				}
 			},
-			"match": "(\\\\)(?:[A-Za-z@]+|[,;])",
+			"match": "(\\\\)(?:[\\p{Alphabetic}@]+|[,;])",
 			"name": "support.function.general.tex"
 		},
 		{


### PR DESCRIPTION
Fixes #48 

<img width="251" alt="image" src="https://user-images.githubusercontent.com/3607926/230133562-b225126a-869b-4474-bdea-44c9bb9146dc.png">
