### PR TITLE
Highlight single and double citations in text

### DIFF
--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -2049,7 +2049,7 @@
 		},
 		{
 			"name": "string.quoted.double.latex",
-			"match": "(?:\\s*)(\\`\\`)(?:.*?)(\\'\\'|\\\")",
+			"match": "(?:\\s*)[^\\\\](\\`\\`)(?:.*?[^\\\\])(\\'\\'|\\\")",
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.string.begin.latex"
@@ -2061,7 +2061,7 @@
 		},
 		{
 			"name": "string.quoted.single.latex",
-			"match": "(?:\\s*)(\\`)(?:.*?)(\\')",
+			"match": "(?:\\s*)[^\\\\](\\`)(?:.*?[^\\\\])(\\')",
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.string.begin.latex"

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -2048,6 +2048,30 @@
 			]
 		},
 		{
+			"name": "string.quoted.double.latex",
+			"match": "(?:\\s*)(\\`\\`)(?:.*?)(\\'\\'|\\\")",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.latex"
+				},
+				"2": {
+					"name": "punctuation.definition.string.end.latex"
+				}
+			}
+		},
+		{
+			"name": "string.quoted.single.latex",
+			"match": "(?:\\s*)(\\`)(?:.*?)(\\')",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.latex"
+				},
+				"2": {
+					"name": "punctuation.definition.string.end.latex"
+				}
+			}
+		},
+		{
 			"begin": "\\$\\$",
 			"beginCaptures": {
 				"0": {


### PR DESCRIPTION
Words or sentences inside single or double citation marks ` ``like this''` will be highlighted as a string.

Pretty straight-forward. Captures everything except newlines. 