### PR TITLE
Extend syntax highlighting for hyperlinks

### DIFF
--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1198,16 +1198,32 @@
 					"name": "punctuation.definition.function.latex"
 				},
 				"3": {
-					"name": "punctuation.definition.arguments.begin.latex"
+					"patterns": [
+						{
+							"include": "#optional-arg"
+						}
+					]
 				},
 				"4": {
-					"name": "markup.underline.link.latex"
+					"name": "punctuation.definition.arguments.begin.latex"
 				},
 				"5": {
+					"name": "markup.underline.link.latex"
+				},
+				"6": {
+					"name": "punctuation.definition.arguments.end.latex"
+				},
+				"7": {
+					"name": "punctuation.definition.arguments.begin.latex"
+				},
+				"8": {
+					"name": "entity.name.hyperlink.latex"
+				},
+				"9": {
 					"name": "punctuation.definition.arguments.end.latex"
 				}
 			},
-			"match": "(?:\\s*)((\\\\)(?:url|href))(\\{)([^}]*)(\\})",
+			"match": "(?:\\s*)((\\\\)(?:url|href|hyperref|hyperimage))((?:\\[[^\\[]*?\\])*)(\\{)([^}]*)(\\})(?:(?:\\{[^}]*\\}){2})?(?:(\\{)([^}]*)(\\}))?",
 			"name": "meta.function.link.url.latex"
 		},
 		{


### PR DESCRIPTION
Similar to #52

The definition has been extended to tokenize the URL string and the displayed text
It handles the following common commands:

![Image](https://gcdnb.pbrd.co/images/MIXorEkrTLdb.png?o=1)