### PR TITLE
Update source code listings

### DIFF
--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -148,7 +148,7 @@
 			]
 		},
 		{
-			"begin": "(^\\s*)?\\\\begin\\{(lstlisting|minted|pyglist)\\}(?=\\[|\\{)",
+			"begin": "(^\\s*)?\\\\begin\\{(lstlisting|minted|pyglist)\\}",
 			"end": "\\\\end\\{(?:minted|lstlisting|pyglist)\\}",
 			"captures": {
 				"0": {
@@ -479,6 +479,27 @@
 					]
 				},
 				{
+					"begin": "(?:\\G|(?<=\\]))(\\{)((?:octave|matlab))(\\})",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.arguments.begin.latex"
+						},
+						"2": {
+							"name": "variable.parameter.function.latex"
+						},
+						"3": {
+							"name": "punctuation.definition.arguments.end.latex"
+						}
+					},
+					"end": "^\\s*(?=\\\\end\\{(?:minted|lstlisting|pyglist)\\})",
+					"contentName": "source.matlab",
+					"patterns": [
+						{
+							"include": "source.matlab"
+						}
+					]
+				},
+				{
 					"begin": "(?:\\G|(?<=\\]))(\\{)([a-zA-Z]*)(\\})",
 					"beginCaptures": {
 						"1": {
@@ -494,6 +515,23 @@
 					"contentName": "meta.function.embedded.latex",
 					"end": "^\\s*(?=\\\\end\\{(?:lstlisting|minted|pyglist)\\})",
 					"name": "meta.embedded.block.generic.latex"
+				},
+				{
+					"begin": "(?:\\G|(?<=\\]))(?!\\{)(\\s*)(?!\\})",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.arguments.begin.latex"
+						},
+						"2": {
+							"name": "variable.parameter.function.latex"
+						},
+						"3": {
+							"name": "punctuation.definition.arguments.end.latex"
+						}
+					},
+					"contentName": "markup.raw.verb.latex",
+					"end": "^\\s*(?=\\\\end\\{(?:lstlisting|minted|pyglist)\\})",
+					"name": "meta.function.verbatim.latex"
 				}
 			]
 		},


### PR DESCRIPTION
This PR will fix the following:
* previously, the regex string required there to be an opening brace or bracket for the tokenization to work. This has been removed (line 152)
* The "default" state is then to tokenize the content of the listing as "verbatim" unless the language is provided as the second argument (this is actually non-standard behavior, but I didn't want to change too much)

Finally, I added Matlab language support (not natively supported, but very common). Mostly wanted to try it