### PR TITLE
Allow special characters in bibtex @string variables

### DIFF
--- a/syntaxes/Bibtex.tmLanguage.json
+++ b/syntaxes/Bibtex.tmLanguage.json
@@ -124,13 +124,13 @@
 							"include": "#percentage_comment"
 						},
 						{
-							"include": "#string_var"
+							"include": "#integer"
 						},
 						{
 							"include": "#string_content"
 						},
 						{
-							"include": "#integer"
+							"include": "#string_var"
 						}
 					]
 				}
@@ -183,13 +183,13 @@
 							"include": "#percentage_comment"
 						},
 						{
-							"include": "#string_var"
+							"include": "#integer"
 						},
 						{
 							"include": "#string_content"
 						},
 						{
-							"include": "#integer"
+							"include": "#string_var"
 						}
 					]
 				}
@@ -203,8 +203,12 @@
 	],
 	"repository": {
 		"integer": {
-			"match": "\\d+",
-			"name": "constant.numeric.bibtex"
+			"match": "\\s*(\\d+)\\s*",
+			"captures": {
+				"1": {
+					"name": "constant.numeric.bibtex"
+				}
+			}
 		},
 		"nested_braces": {
 			"begin": "(?<!\\\\)\\{",

--- a/syntaxes/Bibtex.tmLanguage.json
+++ b/syntaxes/Bibtex.tmLanguage.json
@@ -20,7 +20,7 @@
 			]
 		},
 		{
-			"begin": "((@)(?i:string))\\s*(\\{)\\s*([a-zA-Z]*)",
+			"begin": "((@)(?i:string))\\s*(\\{)\\s*([a-zA-Z0-9\\!\\$\\&\\*\\+\\-\\.\\/\\:\\;\\<\\>\\?\\[\\]\\^\\_\\`\\|]+)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.other.string-constant.bibtex"
@@ -49,7 +49,7 @@
 			]
 		},
 		{
-			"begin": "((@)(?i:string))\\s*(\\()\\s*([a-zA-Z]*)",
+			"begin": "((@)(?i:string))\\s*(\\()\\s*([a-zA-Z0-9\\!\\$\\&\\*\\+\\-\\.\\/\\:\\;\\<\\>\\?\\[\\]\\^\\_\\`\\|]+)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.other.string-constant.bibtex"
@@ -226,7 +226,7 @@
 			]
 		},
 		"string_var": {
-			"match": "(#)?\\s*([a-zA-Z]+)\\s*(#)?",
+			"match": "(#)?\\s*([a-zA-Z0-9\\!\\$\\&\\*\\+\\-\\.\\/\\:\\;\\<\\>\\?\\[\\]\\^\\_\\`\\|]+)\\s*(#)?",
 			"captures": {
 				"1": {
 					"name": "keyword.operator.bibtex"

--- a/test/colorize-fixtures/test.bib
+++ b/test/colorize-fixtures/test.bib
@@ -1,8 +1,8 @@
 
-@string{ucp = {University of California Press}}
+@string{ucp:2 = {University of California Press}}
 
 @xdata{oup2,
-  publisher = {Oxford University Press},
+  publisher = {Oxford University Press} # ucp:2,
   location  = {Oxford}
 }
 

--- a/test/colorize-results/test_bib.json
+++ b/test/colorize-results/test_bib.json
@@ -12,7 +12,7 @@
 		"t": "text.bibtex meta.string-constant.braces.bibtex punctuation.section.string-constant.begin.bibtex"
 	},
 	{
-		"c": "ucp",
+		"c": "ucp:2",
 		"t": "text.bibtex meta.string-constant.braces.bibtex variable.other.bibtex"
 	},
 	{
@@ -86,6 +86,22 @@
 	{
 		"c": "}",
 		"t": "text.bibtex meta.entry.braces.bibtex meta.key-assignment.bibtex punctuation.definition.string.end.bibtex"
+	},
+	{
+		"c": " ",
+		"t": "text.bibtex meta.entry.braces.bibtex meta.key-assignment.bibtex"
+	},
+	{
+		"c": "#",
+		"t": "text.bibtex meta.entry.braces.bibtex meta.key-assignment.bibtex keyword.operator.bibtex"
+	},
+	{
+		"c": " ",
+		"t": "text.bibtex meta.entry.braces.bibtex meta.key-assignment.bibtex"
+	},
+	{
+		"c": "ucp:2",
+		"t": "text.bibtex meta.entry.braces.bibtex meta.key-assignment.bibtex support.variable.bibtex"
 	},
 	{
 		"c": ",",


### PR DESCRIPTION
Related to https://github.com/James-Yu/LaTeX-Workshop/issues/3835

This PR fixes 

> * Currently, the syntax highlight in `@string` entries breaks if there is non-alphabet character, e.g., in `@string{edn:2 = "Second"}` only `edn` shows color. This also happens when you reuse the abbreviation in entries. I think being able to highlight the whole abbreviation key enhances the experience.

The list of accepted special characters is discussed in https://metacpan.org/release/AMBS/Text-BibTeX-0.66/view/btparse/doc/bt_language.pod
