### PR TITLE
Extended support for hyperlinks, add support for quotes

### DIFF
--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1223,7 +1223,7 @@
 					"name": "punctuation.definition.arguments.end.latex"
 				}
 			},
-			"match": "(?:\\s*)((\\\\)(?:url|href|hyperref|hyperimage))((?:\\[[^\\[]*?\\])*)(\\{)([^}]*)(\\})(?:(?:\\{[^}]*\\}){2})?(?:(\\{)([^}]*)(\\}))?",
+			"match": "(?:\\s*)((\\\\)(?:url|href|hyperref|hyperimage))(\\[[^\\[]*?\\])?(\\{)([^}]*)(\\})(?:\\{[^}]*\\}){2}?(?:(\\{)([^}]*)(\\}))?",
 			"name": "meta.function.link.url.latex"
 		},
 		{

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1198,16 +1198,32 @@
 					"name": "punctuation.definition.function.latex"
 				},
 				"3": {
-					"name": "punctuation.definition.arguments.begin.latex"
+					"patterns": [
+						{
+							"include": "#optional-arg"
+						}
+					]
 				},
 				"4": {
-					"name": "markup.underline.link.latex"
+					"name": "punctuation.definition.arguments.begin.latex"
 				},
 				"5": {
+					"name": "markup.underline.link.latex"
+				},
+				"6": {
+					"name": "punctuation.definition.arguments.end.latex"
+				},
+				"7": {
+					"name": "punctuation.definition.arguments.begin.latex"
+				},
+				"8": {
+					"name": "entity.name.hyperlink.latex"
+				},
+				"9": {
 					"name": "punctuation.definition.arguments.end.latex"
 				}
 			},
-			"match": "(?:\\s*)((\\\\)(?:url|href))(\\{)([^}]*)(\\})",
+			"match": "(?:\\s*)((\\\\)(?:url|href|hyperref|hyperimage))((?:\\[[^\\[]*?\\])*)(\\{)([^}]*)(\\})(?:(?:\\{[^}]*\\}){2})?(?:(\\{)([^}]*)(\\}))?",
 			"name": "meta.function.link.url.latex"
 		},
 		{
@@ -2046,6 +2062,30 @@
 					"include": "$base"
 				}
 			]
+		},
+		{
+			"name": "string.quoted.double.latex",
+			"match": "(?!\\\\)(\\`\\`)(?:.*?[^\\\\])(\\'\\'|\\\")",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.latex"
+				},
+				"2": {
+					"name": "punctuation.definition.string.end.latex"
+				}
+			}
+		},
+		{
+			"name": "string.quoted.single.latex",
+			"match": "(?!\\\\)(\\`)(?:.*?[^\\\\])(\\')",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.latex"
+				},
+				"2": {
+					"name": "punctuation.definition.string.end.latex"
+				}
+			}
 		},
 		{
 			"begin": "\\$\\$",

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -2065,7 +2065,7 @@
 		},
 		{
 			"name": "string.quoted.double.latex",
-			"match": "(?!\\\\)(\\`\\`)(?:.*?[^\\\\])(\\'\\'|\\\")",
+			"match": "(?<!\\\\)(\\`\\`)(?:.*?(?<!\\\\))(\\'\\'|\\\")",
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.string.begin.latex"
@@ -2077,7 +2077,7 @@
 		},
 		{
 			"name": "string.quoted.single.latex",
-			"match": "(?!\\\\)(\\`)(?:.*?[^\\\\])(\\')",
+			"match": "(?<!\\\\)(\\`)(?:.*?(?<!\\\\))(\\')",
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.string.begin.latex"

--- a/syntaxes/data/LaTeX.tmLanguage.json
+++ b/syntaxes/data/LaTeX.tmLanguage.json
@@ -351,7 +351,7 @@
 					"name": "punctuation.definition.arguments.end.latex"
 				}
 			},
-			"match": "(?:\\s*)((\\\\)(?:url|href|hyperref|hyperimage))((?:\\[[^\\[]*?\\])*)(\\{)([^}]*)(\\})(?:(?:\\{[^}]*\\}){2})?(?:(\\{)([^}]*)(\\}))?",
+			"match": "(?:\\s*)((\\\\)(?:url|href|hyperref|hyperimage))(\\[[^\\[]*?\\])?(\\{)([^}]*)(\\})(?:\\{[^}]*\\}){2}?(?:(\\{)([^}]*)(\\}))?",
 			"name": "meta.function.link.url.latex"
 		},
 		{

--- a/syntaxes/data/LaTeX.tmLanguage.json
+++ b/syntaxes/data/LaTeX.tmLanguage.json
@@ -1193,7 +1193,7 @@
 		},
 		{
 			"name": "string.quoted.double.latex",
-			"match": "(?!\\\\)(\\`\\`)(?:.*?[^\\\\])(\\'\\'|\\\")",
+			"match": "(?<!\\\\)(\\`\\`)(?:.*?(?<!\\\\))(\\'\\'|\\\")",
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.string.begin.latex"
@@ -1205,7 +1205,7 @@
 		},
 		{
 			"name": "string.quoted.single.latex",
-			"match": "(?!\\\\)(\\`)(?:.*?[^\\\\])(\\')",
+			"match": "(?<!\\\\)(\\`)(?:.*?(?<!\\\\))(\\')",
 			"captures": {
 				"1": {
 					"name": "punctuation.definition.string.begin.latex"

--- a/syntaxes/data/LaTeX.tmLanguage.json
+++ b/syntaxes/data/LaTeX.tmLanguage.json
@@ -326,16 +326,32 @@
 					"name": "punctuation.definition.function.latex"
 				},
 				"3": {
-					"name": "punctuation.definition.arguments.begin.latex"
+					"patterns": [
+						{
+							"include": "#optional-arg"
+						}
+					]
 				},
 				"4": {
-					"name": "markup.underline.link.latex"
+					"name": "punctuation.definition.arguments.begin.latex"
 				},
 				"5": {
+					"name": "markup.underline.link.latex"
+				},
+				"6": {
+					"name": "punctuation.definition.arguments.end.latex"
+				},
+				"7": {
+					"name": "punctuation.definition.arguments.begin.latex"
+				},
+				"8": {
+					"name": "entity.name.hyperlink.latex"
+				},
+				"9": {
 					"name": "punctuation.definition.arguments.end.latex"
 				}
 			},
-			"match": "(?:\\s*)((\\\\)(?:url|href))(\\{)([^}]*)(\\})",
+			"match": "(?:\\s*)((\\\\)(?:url|href|hyperref|hyperimage))((?:\\[[^\\[]*?\\])*)(\\{)([^}]*)(\\})(?:(?:\\{[^}]*\\}){2})?(?:(\\{)([^}]*)(\\}))?",
 			"name": "meta.function.link.url.latex"
 		},
 		{
@@ -1174,6 +1190,30 @@
 					"include": "$base"
 				}
 			]
+		},
+		{
+			"name": "string.quoted.double.latex",
+			"match": "(?!\\\\)(\\`\\`)(?:.*?[^\\\\])(\\'\\'|\\\")",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.latex"
+				},
+				"2": {
+					"name": "punctuation.definition.string.end.latex"
+				}
+			}
+		},
+		{
+			"name": "string.quoted.single.latex",
+			"match": "(?!\\\\)(\\`)(?:.*?[^\\\\])(\\')",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.string.begin.latex"
+				},
+				"2": {
+					"name": "punctuation.definition.string.end.latex"
+				}
+			}
 		},
 		{
 			"begin": "\\$\\$",


### PR DESCRIPTION
Another attempt at #53, and #51.

The grammars have been extended to tokenize the URL string and the displayed text when creating hyperlinks.
It handles the following common commands:

![Image](https://gcdnb.pbrd.co/images/MIXorEkrTLdb.png?o=1)

Additionally, words or sentences inside single or double citation marks ` ``like this''` will be highlighted as a string.
Captures everything except newlines. Negative lookbehind prevents false positives when characters are escaped