### PR TITLE
Support  macro `\cacheMeCode` from robust-externalize

### DIFF
--- a/build/generate-latex-grammars.mjs
+++ b/build/generate-latex-grammars.mjs
@@ -8,26 +8,26 @@ const syntaxesSrcDir = './src'
 const mintedEnvs = ['minted', 'lstlisting', 'pyglist']
 const robustExternalizeEnvs = ['CacheMeCode', 'PlaceholderPathFromCode\\*?', 'PlaceholderFromCode\\*?', 'SetPlaceholderCode\\*?']
 const mintedLanguages = [
-    {language: ['asy', 'asymptote'], source: 'source.asy'},
-    {language: ['bash'], source: 'source.shell'},
-    {language: ['c', 'cpp'], source: 'source.cpp.embedded.latex'},
-    {language: ['css'], source: 'source.css'},
-    {language: ['gnuplot'], source: 'source.gnuplot'},
-    {language: ['hs', 'haskell'], source: 'source.haskell'},
-    {language: ['html'], source: 'text.html.basic', contentName: 'text.html'},
-    {language: ['java'], source: 'source.java'},
-    {language: ['jl', 'julia'], source: 'source.julia'},
-    {language: ['js', 'javascript'], source: 'source.js'},
-    {language: ['lua'], source: 'source.lua'},
-    {language: ['py', 'python', 'sage'], source: 'source.python'},
-    {language: ['rb', 'ruby'], source: 'source.ruby'},
-    {language: ['rust'], source: 'source.rust'},
-    {language: ['ts', 'typescript'], source: 'source.ts'},
-    {language: ['xml'], source: 'text.xml'},
-    {language: ['yaml'], source: 'source.yaml'},
+    {name: ['asy', 'asymptote'], source: 'source.asy'},
+    {name: ['bash'], source: 'source.shell'},
+    {name: ['c', 'cpp'], source: 'source.cpp.embedded.latex'},
+    {name: ['css'], source: 'source.css'},
+    {name: ['gnuplot'], source: 'source.gnuplot'},
+    {name: ['hs', 'haskell'], source: 'source.haskell'},
+    {name: ['html'], source: 'text.html.basic', contentName: 'text.html'},
+    {name: ['java'], source: 'source.java'},
+    {name: ['jl', 'julia'], source: 'source.julia'},
+    {name: ['js', 'javascript'], source: 'source.js'},
+    {name: ['lua'], source: 'source.lua'},
+    {name: ['py', 'python', 'sage'], source: 'source.python'},
+    {name: ['rb', 'ruby'], source: 'source.ruby'},
+    {name: ['rust'], source: 'source.rust'},
+    {name: ['ts', 'typescript'], source: 'source.ts'},
+    {name: ['xml'], source: 'text.xml'},
+    {name: ['yaml'], source: 'source.yaml'},
 ]
 const robustExternalizeLanguages = mintedLanguages.concat(
-    {language: ['tikz', 'tikzpicture'], source: 'text.tex.latex'}
+    {name: ['tikz', 'tikzpicture'], source: 'text.tex.latex'}
 )
 
 const codeLanguages = [
@@ -77,7 +77,7 @@ function escapeBackSlash(text) {
 }
 
 /**
- * Generate the json rules for a code block:
+ * Generate the yaml rules for a code block:
  *  From pythontex `\begin{<env>}[<session>][<fancyvrb setting>]`
  *  From minted `\begin{<env>}[<option list>]{<option list>}`
  * We match \begin{<env>}[<session>][<option list>]{<option list>} where the
@@ -90,7 +90,7 @@ function generateCodeBlock(envNames, source, contentName=undefined) {
     if (contentName === undefined) {
         contentName = source
     }
-    var envNameRegex = '(?:' + envNames.join('|') + ')'
+    const envNameRegex = '(?:' + envNames.join('|') + ')'
     const beginRule = `\\s*\\\\begin\\{${envNameRegex}\\*?\\}(?:\\[[a-zA-Z0-9_-]*\\])?(?=\\[|\\{|\\s*$)`
     const endRule = `\\s*\\\\end\\{${envNameRegex}\\*?\\}`
 
@@ -121,7 +121,7 @@ function generateCodeBlock(envNames, source, contentName=undefined) {
 }
 
 /**
- * Generate the json rules for a minted type block
+ * Generate the yaml rules for a minted type block
  * @param {string[]} envNames Typically minted
  * @param {string[]} language A list of languages used to build an alternation
  * @param {string} source The source language to include
@@ -131,8 +131,8 @@ function generateMintedBlock(envNames, language, source, contentName=undefined) 
     if (contentName === undefined) {
         contentName = source
     }
-    var languageRegex = '(?:' + language.join('|') + ')'
-    var envNameRegex = '(?:' + envNames.join('|') + ')'
+    const languageRegex = '(?:' + language.join('|') + ')'
+    const envNameRegex = '(?:' + envNames.join('|') + ')'
 
     const yamlCode = `- begin: (?:\\G|(?<=\\]))(\\{)(${languageRegex})(\\})
   beginCaptures:
@@ -151,18 +151,18 @@ function generateMintedBlock(envNames, language, source, contentName=undefined) 
 }
 
 /**
- * Generate the json rules for a robust externalize type block
+ * Generate the yaml rules for a robust externalize type block
  * @param {string[]} envNames Typically CacheMeCode
  * @param {string[]} language A list of languages used to build an alternation
  * @param {string} source The source language to include
  * @param {string} contentName The scope to assign to the content. If undefined, use {@link source}
  */
-function generateRobustExternalizeBlock(envNames, language, source, contentName=undefined) {
+function generateRobustExternalizeEnvsBlock(envNames, language, source, contentName=undefined) {
     if (contentName === undefined) {
         contentName = source
     }
-    var languageRegex = '(?i:' + language.join('|') + ')'
-    var envNameRegex = '(?:RobExt)?' + '(?:' + envNames.join('|') + ')'
+    const languageRegex = '(?i:' + language.join('|') + ')'
+    const envNameRegex = '(?:RobExt)?' + '(?:' + envNames.join('|') + ')'
 
     const yamlCode = `- begin: \\G(\\{)(?:__|[a-z\\s]*)${languageRegex}
   end: (?=\\\\end\\{${envNameRegex}\\})
@@ -187,16 +187,54 @@ function generateRobustExternalizeBlock(envNames, language, source, contentName=
     return escapeBackSlash(yamlCode)
 }
 
+/**
+ * Generate the yaml rules for the \cacheMeCode macro
+ * @param {string[]} language A list of languages used to build an alternation
+ * @param {string} source The source language to include
+ * @param {string} contentName The scope to assign to the content. If undefined, use {@link source}
+ */
+function generateCacheMeCodeMacroBlock(language, source, contentName=undefined) {
+    if (contentName === undefined) {
+        contentName = source
+    }
+    const languageRegex = '(?i:' + language.join('|') + ')'
+
+    const yamlCode = `- begin: ((\\\\)cacheMeCode)(?=\\[${languageRegex}\\b|\\{)
+  end: (?<=\\})
+  beginCaptures:
+    '1':
+      name: support.function.verb.latex
+    '2':
+      name: punctuation.definition.function.latex
+  patterns:
+  - include: text.tex.latex#multiline-optional-arg-no-highlight
+  - begin: (?<=\\])(\\{)
+    end: \\}
+    beginCaptures:
+      '0':
+        name: punctuation.definition.arguments.begin.latex
+    endCaptures:
+      '0':
+        name: punctuation.definition.arguments.end.latex
+    contentName: ${contentName}
+    patterns:
+    - include: ${source}`
+
+    return escapeBackSlash(yamlCode)
+}
+
 function buildLatexBlocks() {
-    var mintedDefinitions = mintedLanguages.map(language => generateMintedBlock(mintedEnvs, language.language, language.source, language?.contentName)).join('\n')
-    var codeDefinitions = codeLanguages.map(language => generateCodeBlock(language.name, language.source, language?.contentName)).join('\n')
-    var robustExternalizeDefinitions = robustExternalizeLanguages.map(language => generateRobustExternalizeBlock(robustExternalizeEnvs, language.language, language.source, language?.contentName)).join('\n')
+    const mintedDefinitions = mintedLanguages.map(language => generateMintedBlock(mintedEnvs, language.name, language.source, language?.contentName)).join('\n')
+    const codeDefinitions = codeLanguages.map(language => generateCodeBlock(language.name, language.source, language?.contentName)).join('\n')
+    const cacheMeCodeMacroDefinitions = robustExternalizeLanguages.map(language => generateCacheMeCodeMacroBlock(language.name, language.source, language?.contentName)).join('\n')
+    const robustExternalizeDefinitions = robustExternalizeLanguages.map(language => generateRobustExternalizeEnvsBlock(robustExternalizeEnvs, language.name, language.source, language?.contentName)).join('\n')
 
     try {
         let yamlGrammar = fs.readFileSync(path.join(syntaxesSrcDir, 'LaTeX.tmLanguage.base.yaml'), {encoding: 'utf-8'})
         yamlGrammar = yamlGrammar.replace(/^\s{2}- includeRobustExternalizeBlocks: ''/m, indent(2, robustExternalizeDefinitions))
         yamlGrammar = yamlGrammar.replace(/^- includeCodeBlocks: ''/m, codeDefinitions)
         yamlGrammar = yamlGrammar.replace(/^\s{2}- includeMintedblocks: ''/m, indent(2, mintedDefinitions))
+        yamlGrammar = yamlGrammar.replace(/^- includeCacheMeCodeMacroBlock: ''/m, cacheMeCodeMacroDefinitions)
         const latexGrammar = yaml.load(yamlGrammar)
         return latexGrammar
     } catch (error) {

--- a/build/generate-latex-grammars.mjs
+++ b/build/generate-latex-grammars.mjs
@@ -151,8 +151,8 @@ function generateMintedBlock(envNames, language, source, contentName=undefined) 
 }
 
 /**
- * Generate the json rules for a minted type block
- * @param {string[]} envNames Typically minted
+ * Generate the json rules for a robust externalize type block
+ * @param {string[]} envNames Typically CacheMeCode
  * @param {string[]} language A list of languages used to build an alternation
  * @param {string} source The source language to include
  * @param {string} contentName The scope to assign to the content. If undefined, use {@link source}

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -177,27 +177,59 @@ patterns:
     '2':
       name: punctuation.definition.function.latex
   patterns:
-  - begin: \[
-    end: \]
+  - begin: \G(\[)
     beginCaptures:
-      '0':
+      '1':
         name: punctuation.definition.arguments.optional.begin.latex
-    endCaptures:
-      '0':
-        name: punctuation.definition.arguments.optional.end.latex
+    end: (?=\})
     patterns:
-    - include: text.tex#braces
-    - include: $base
-  - begin: (?<=\])\{
-    end: \}
-    beginCaptures:
-      '0':
-        name: punctuation.definition.arguments.begin.latex
-    endCaptures:
-      '0':
-        name: punctuation.definition.arguments.end.latex
-    contentName: meta.function.embedded.latex
-    name: meta.embedded.block.generic.latex
+    - begin: \G
+      end: (\])(?=\{)
+      endCaptures:
+        '1':
+          name: punctuation.definition.arguments.optional.end.latex
+      patterns:
+      - include: text.tex#braces
+      - include: $base
+    - begin: (?<=\])(\{)
+      end: (\})
+      beginCaptures:
+        '0':
+          name: punctuation.definition.arguments.begin.latex
+      endCaptures:
+        '0':
+          name: punctuation.definition.arguments.end.latex
+      contentName: meta.function.embedded.latex
+      name: meta.embedded.block.generic.latex
+# - begin: ((\\)cacheMeCode(?=\[))
+#   end: (?<=\})
+#   beginCaptures:
+#     '1':
+#       name: support.function.verb.latex
+#     '2':
+#       name: punctuation.definition.function.latex
+#   patterns:
+#   - begin: \[
+#     end: \]
+#     beginCaptures:
+#       '0':
+#         name: punctuation.definition.arguments.optional.begin.latex
+#     endCaptures:
+#       '0':
+#         name: punctuation.definition.arguments.optional.end.latex
+#     patterns:
+#     - include: text.tex#braces
+#     - include: $base
+#   - begin: (?<=\])\{
+#     end: \}
+#     beginCaptures:
+#       '0':
+#         name: punctuation.definition.arguments.begin.latex
+#     endCaptures:
+#       '0':
+#         name: punctuation.definition.arguments.end.latex
+#     contentName: meta.function.embedded.latex
+#     name: meta.embedded.block.generic.latex
 - begin: ((\\)addplot)(?:\+?)((?:\[[^\[]*\]))*\s*(gnuplot)\s*((?:\[[^\[]*\]))*\s*(\{)
   captures:
     '1':

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -169,6 +169,35 @@ patterns:
     contentName: meta.function.embedded.latex
     end: ^\s*(?=\\end\{terminal\*?\})
     name: meta.embedded.block.generic.latex
+- begin: ((\\)cacheMeCode(?=\[))
+  end: (?<=\})
+  beginCaptures:
+    '1':
+      name: support.function.verb.latex
+    '2':
+      name: punctuation.definition.function.latex
+  patterns:
+  - begin: \[
+    end: \]
+    beginCaptures:
+      '0':
+        name: punctuation.definition.arguments.optional.begin.latex
+    endCaptures:
+      '0':
+        name: punctuation.definition.arguments.optional.end.latex
+    patterns:
+    - include: text.tex#braces
+    - include: $base
+  - begin: (?<=\])\{
+    end: \}
+    beginCaptures:
+      '0':
+        name: punctuation.definition.arguments.begin.latex
+    endCaptures:
+      '0':
+        name: punctuation.definition.arguments.end.latex
+    contentName: meta.function.embedded.latex
+    name: meta.embedded.block.generic.latex
 - begin: ((\\)addplot)(?:\+?)((?:\[[^\[]*\]))*\s*(gnuplot)\s*((?:\[[^\[]*\]))*\s*(\{)
   captures:
     '1':

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -169,69 +169,34 @@ patterns:
     contentName: meta.function.embedded.latex
     end: ^\s*(?=\\end\{terminal\*?\})
     name: meta.embedded.block.generic.latex
-- begin: ((\\)cacheMeCode(?=\[))
-  end: \}
+- begin: ((\\)cacheMeCode)(?=\[|\{)
+  end: (?<=\})
   beginCaptures:
     '1':
       name: support.function.verb.latex
     '2':
       name: punctuation.definition.function.latex
-  endCaptures:
-    '0':
-      name: punctuation.definition.arguments.end.latex
   patterns:
   - begin: \G(\[)
     beginCaptures:
       '1':
         name: punctuation.definition.arguments.optional.begin.latex
-    end: (?=\})
+    end: \]
+    endCaptures:
+      '0':
+        name: punctuation.definition.arguments.optional.end.latex
+    name: meta.parameter.optional.latex
+  - begin: (?<=\])(\{)
+    end: \}
+    beginCaptures:
+      '0':
+        name: punctuation.definition.arguments.begin.latex
+    endCaptures:
+      '0':
+        name: punctuation.definition.arguments.end.latex
     patterns:
-    - begin: \G
-      end: (\])(?=\{)
-      endCaptures:
-        '1':
-          name: punctuation.definition.arguments.optional.end.latex
-      patterns:
-      - include: text.tex#braces
-      - include: $base
-    - begin: (?<=\])(\{)
-      end: (?=\})
-      beginCaptures:
-        '0':
-          name: punctuation.definition.arguments.begin.latex
-      patterns:
-      - include: text.tex#braces
-      contentName: meta.function.embedded.latex
-      name: meta.embedded.block.generic.latex
-# - begin: ((\\)cacheMeCode(?=\[))
-#   end: (?<=\})
-#   beginCaptures:
-#     '1':
-#       name: support.function.verb.latex
-#     '2':
-#       name: punctuation.definition.function.latex
-#   patterns:
-#   - begin: \[
-#     end: \]
-#     beginCaptures:
-#       '0':
-#         name: punctuation.definition.arguments.optional.begin.latex
-#     endCaptures:
-#       '0':
-#         name: punctuation.definition.arguments.optional.end.latex
-#     patterns:
-#     - include: text.tex#braces
-#     - include: $base
-#   - begin: (?<=\])\{
-#     end: \}
-#     beginCaptures:
-#       '0':
-#         name: punctuation.definition.arguments.begin.latex
-#     endCaptures:
-#       '0':
-#         name: punctuation.definition.arguments.end.latex
-#     contentName: meta.function.embedded.latex
-#     name: meta.embedded.block.generic.latex
+    - include: text.tex#braces
+    name: meta.embedded.block.generic.latex
 - begin: ((\\)addplot)(?:\+?)((?:\[[^\[]*\]))*\s*(gnuplot)\s*((?:\[[^\[]*\]))*\s*(\{)
   captures:
     '1':

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -169,6 +169,7 @@ patterns:
     contentName: meta.function.embedded.latex
     end: ^\s*(?=\\end\{terminal\*?\})
     name: meta.embedded.block.generic.latex
+- includeCacheMeCodeMacroBlock: ''
 - begin: ((\\)cacheMeCode)(?=\[|\{)
   end: (?<=\})
   beginCaptures:
@@ -177,15 +178,7 @@ patterns:
     '2':
       name: punctuation.definition.function.latex
   patterns:
-  - begin: \G(\[)
-    beginCaptures:
-      '1':
-        name: punctuation.definition.arguments.optional.begin.latex
-    end: \]
-    endCaptures:
-      '0':
-        name: punctuation.definition.arguments.optional.end.latex
-    name: meta.parameter.optional.latex
+  - include: text.tex.latex#multiline-optional-arg-no-highlight
   - begin: (?<=\])(\{)
     end: \}
     beginCaptures:
@@ -194,9 +187,9 @@ patterns:
     endCaptures:
       '0':
         name: punctuation.definition.arguments.end.latex
+    contentName: meta.embedded.block.generic.latex
     patterns:
     - include: text.tex#braces
-    name: meta.embedded.block.generic.latex
 - begin: ((\\)addplot)(?:\+?)((?:\[[^\[]*\]))*\s*(gnuplot)\s*((?:\[[^\[]*\]))*\s*(\{)
   captures:
     '1':

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -170,12 +170,15 @@ patterns:
     end: ^\s*(?=\\end\{terminal\*?\})
     name: meta.embedded.block.generic.latex
 - begin: ((\\)cacheMeCode(?=\[))
-  end: (?<=\})
+  end: \}
   beginCaptures:
     '1':
       name: support.function.verb.latex
     '2':
       name: punctuation.definition.function.latex
+  endCaptures:
+    '0':
+      name: punctuation.definition.arguments.end.latex
   patterns:
   - begin: \G(\[)
     beginCaptures:
@@ -192,13 +195,12 @@ patterns:
       - include: text.tex#braces
       - include: $base
     - begin: (?<=\])(\{)
-      end: (\})
+      end: (?=\})
       beginCaptures:
         '0':
           name: punctuation.definition.arguments.begin.latex
-      endCaptures:
-        '0':
-          name: punctuation.definition.arguments.end.latex
+      patterns:
+      - include: text.tex#braces
       contentName: meta.function.embedded.latex
       name: meta.embedded.block.generic.latex
 # - begin: ((\\)cacheMeCode(?=\[))

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -2046,7 +2046,7 @@
                     ]
                 },
                 {
-                    "begin": "((\\\\)cacheMeCode)(?=\\[|\\{)",
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:asy|asymptote)\\b|\\{)",
                     "end": "(?<=\\})",
                     "beginCaptures": {
                         "1": {
@@ -2058,19 +2058,7 @@
                     },
                     "patterns": [
                         {
-                            "begin": "\\G(\\[)",
-                            "beginCaptures": {
-                                "1": {
-                                    "name": "punctuation.definition.arguments.optional.begin.latex"
-                                }
-                            },
-                            "end": "\\]",
-                            "endCaptures": {
-                                "0": {
-                                    "name": "punctuation.definition.arguments.optional.end.latex"
-                                }
-                            },
-                            "name": "meta.parameter.optional.latex"
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
                         },
                         {
                             "begin": "(?<=\\])(\\{)",
@@ -2085,12 +2073,678 @@
                                     "name": "punctuation.definition.arguments.end.latex"
                                 }
                             },
+                            "contentName": "source.asy",
+                            "patterns": [
+                                {
+                                    "include": "source.asy"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:bash)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.shell",
+                            "patterns": [
+                                {
+                                    "include": "source.shell"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:c|cpp)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.cpp.embedded.latex",
+                            "patterns": [
+                                {
+                                    "include": "source.cpp.embedded.latex"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:css)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.css",
+                            "patterns": [
+                                {
+                                    "include": "source.css"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:gnuplot)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.gnuplot",
+                            "patterns": [
+                                {
+                                    "include": "source.gnuplot"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:hs|haskell)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.haskell",
+                            "patterns": [
+                                {
+                                    "include": "source.haskell"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:html)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "text.html",
+                            "patterns": [
+                                {
+                                    "include": "text.html.basic"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:java)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.java",
+                            "patterns": [
+                                {
+                                    "include": "source.java"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:jl|julia)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.julia",
+                            "patterns": [
+                                {
+                                    "include": "source.julia"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:js|javascript)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.js",
+                            "patterns": [
+                                {
+                                    "include": "source.js"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:lua)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.lua",
+                            "patterns": [
+                                {
+                                    "include": "source.lua"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:py|python|sage)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.python",
+                            "patterns": [
+                                {
+                                    "include": "source.python"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:rb|ruby)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.ruby",
+                            "patterns": [
+                                {
+                                    "include": "source.ruby"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:rust)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.rust",
+                            "patterns": [
+                                {
+                                    "include": "source.rust"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:ts|typescript)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.ts",
+                            "patterns": [
+                                {
+                                    "include": "source.ts"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:xml)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "text.xml",
+                            "patterns": [
+                                {
+                                    "include": "text.xml"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:yaml)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "source.yaml",
+                            "patterns": [
+                                {
+                                    "include": "source.yaml"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[(?i:tikz|tikzpicture)\\b|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "text.tex.latex",
+                            "patterns": [
+                                {
+                                    "include": "text.tex.latex"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "meta.embedded.block.generic.latex",
                             "patterns": [
                                 {
                                     "include": "text.tex#braces"
                                 }
-                            ],
-                            "name": "meta.embedded.block.generic.latex"
+                            ]
                         }
                     ]
                 },

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -2046,6 +2046,55 @@
                     ]
                 },
                 {
+                    "begin": "((\\\\)cacheMeCode)(?=\\[|\\{)",
+                    "end": "(?<=\\})",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.verb.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "\\G(\\[)",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.arguments.optional.begin.latex"
+                                }
+                            },
+                            "end": "\\]",
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.optional.end.latex"
+                                }
+                            },
+                            "name": "meta.parameter.optional.latex"
+                        },
+                        {
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "\\}",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "patterns": [
+                                {
+                                    "include": "text.tex#braces"
+                                }
+                            ],
+                            "name": "meta.embedded.block.generic.latex"
+                        }
+                    ]
+                },
+                {
                     "begin": "((\\\\)addplot)(?:\\+?)((?:\\[[^\\[]*\\]))*\\s*(gnuplot)\\s*((?:\\[[^\\[]*\\]))*\\s*(\\{)",
                     "captures": {
                         "1": {

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1961,42 +1961,49 @@
             },
             "patterns": [
                 {
-                    "begin": "\\[",
-                    "end": "\\]",
+                    "begin": "\\G(\\[)",
                     "beginCaptures": {
-                        "0": {
+                        "1": {
                             "name": "punctuation.definition.arguments.optional.begin.latex"
                         }
                     },
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.arguments.optional.end.latex"
-                        }
-                    },
+                    "end": "(?=\\})",
+                    "contentName": "poo",
                     "patterns": [
                         {
-                            "include": "text.tex#braces"
+                            "begin": "\\G",
+                            "end": "(\\])(?=\\{)",
+                            "endCaptures": {
+                                "1": {
+                                    "name": "punctuation.definition.arguments.optional.end.latex"
+                                }
+                            },
+                            "patterns": [
+                                {
+                                    "include": "text.tex#braces"
+                                },
+                                {
+                                    "include": "$base"
+                                }
+                            ]
                         },
                         {
-                            "include": "$base"
+                            "begin": "(?<=\\])(\\{)",
+                            "end": "(\\})",
+                            "beginCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.begin.latex"
+                                }
+                            },
+                            "endCaptures": {
+                                "0": {
+                                    "name": "punctuation.definition.arguments.end.latex"
+                                }
+                            },
+                            "contentName": "meta.function.embedded.latex",
+                            "name": "meta.embedded.block.generic.latex"
                         }
                     ]
-                },
-                {
-                    "begin": "(?<=\\])\\{",
-                    "end": "\\}",
-                    "beginCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.arguments.begin.latex"
-                        }
-                    },
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.arguments.end.latex"
-                        }
-                    },
-                    "contentName": "meta.function.embedded.latex",
-                    "name": "meta.embedded.block.generic.latex"
                 }
             ]
         },

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1950,13 +1950,18 @@
         },
         {
             "begin": "((\\\\)cacheMeCode(?=\\[))",
-            "end": "(?<=\\})",
+            "end": "\\}",
             "beginCaptures": {
                 "1": {
                     "name": "support.function.verb.latex"
                 },
                 "2": {
                     "name": "punctuation.definition.function.latex"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.arguments.end.latex"
                 }
             },
             "patterns": [
@@ -1968,7 +1973,6 @@
                         }
                     },
                     "end": "(?=\\})",
-                    "contentName": "poo",
                     "patterns": [
                         {
                             "begin": "\\G",
@@ -1989,15 +1993,10 @@
                         },
                         {
                             "begin": "(?<=\\])(\\{)",
-                            "end": "(\\})",
+                            "end": "(?=\\})",
                             "beginCaptures": {
                                 "0": {
                                     "name": "punctuation.definition.arguments.begin.latex"
-                                }
-                            },
-                            "endCaptures": {
-                                "0": {
-                                    "name": "punctuation.definition.arguments.end.latex"
                                 }
                             },
                             "contentName": "meta.function.embedded.latex",

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1949,7 +1949,7 @@
             ]
         },
         {
-            "begin": "((\\\\)cacheMeCode)(?=\\[|\\{)",
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:asy|asymptote)\\b|\\{)",
             "end": "(?<=\\})",
             "beginCaptures": {
                 "1": {
@@ -1961,19 +1961,7 @@
             },
             "patterns": [
                 {
-                    "begin": "\\G(\\[)",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.arguments.optional.begin.latex"
-                        }
-                    },
-                    "end": "\\]",
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.arguments.optional.end.latex"
-                        }
-                    },
-                    "name": "meta.parameter.optional.latex"
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
                 },
                 {
                     "begin": "(?<=\\])(\\{)",
@@ -1988,12 +1976,678 @@
                             "name": "punctuation.definition.arguments.end.latex"
                         }
                     },
+                    "contentName": "source.asy",
+                    "patterns": [
+                        {
+                            "include": "source.asy"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:bash)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.shell",
+                    "patterns": [
+                        {
+                            "include": "source.shell"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:c|cpp)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.cpp.embedded.latex",
+                    "patterns": [
+                        {
+                            "include": "source.cpp.embedded.latex"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:css)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.css",
+                    "patterns": [
+                        {
+                            "include": "source.css"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:gnuplot)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.gnuplot",
+                    "patterns": [
+                        {
+                            "include": "source.gnuplot"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:hs|haskell)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.haskell",
+                    "patterns": [
+                        {
+                            "include": "source.haskell"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:html)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "text.html",
+                    "patterns": [
+                        {
+                            "include": "text.html.basic"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:java)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.java",
+                    "patterns": [
+                        {
+                            "include": "source.java"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:jl|julia)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.julia",
+                    "patterns": [
+                        {
+                            "include": "source.julia"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:js|javascript)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.js",
+                    "patterns": [
+                        {
+                            "include": "source.js"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:lua)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.lua",
+                    "patterns": [
+                        {
+                            "include": "source.lua"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:py|python|sage)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.python",
+                    "patterns": [
+                        {
+                            "include": "source.python"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:rb|ruby)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.ruby",
+                    "patterns": [
+                        {
+                            "include": "source.ruby"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:rust)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.rust",
+                    "patterns": [
+                        {
+                            "include": "source.rust"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:ts|typescript)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.ts",
+                    "patterns": [
+                        {
+                            "include": "source.ts"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:xml)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "text.xml",
+                    "patterns": [
+                        {
+                            "include": "text.xml"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:yaml)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "source.yaml",
+                    "patterns": [
+                        {
+                            "include": "source.yaml"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[(?i:tikz|tikzpicture)\\b|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "text.tex.latex",
+                    "patterns": [
+                        {
+                            "include": "text.tex.latex"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "begin": "((\\\\)cacheMeCode)(?=\\[|\\{)",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "text.tex.latex#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "meta.embedded.block.generic.latex",
                     "patterns": [
                         {
                             "include": "text.tex#braces"
                         }
-                    ],
-                    "name": "meta.embedded.block.generic.latex"
+                    ]
                 }
             ]
         },

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1949,19 +1949,14 @@
             ]
         },
         {
-            "begin": "((\\\\)cacheMeCode(?=\\[))",
-            "end": "\\}",
+            "begin": "((\\\\)cacheMeCode)(?=\\[|\\{)",
+            "end": "(?<=\\})",
             "beginCaptures": {
                 "1": {
                     "name": "support.function.verb.latex"
                 },
                 "2": {
                     "name": "punctuation.definition.function.latex"
-                }
-            },
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.definition.arguments.end.latex"
                 }
             },
             "patterns": [
@@ -1972,37 +1967,33 @@
                             "name": "punctuation.definition.arguments.optional.begin.latex"
                         }
                     },
-                    "end": "(?=\\})",
+                    "end": "\\]",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.optional.end.latex"
+                        }
+                    },
+                    "name": "meta.parameter.optional.latex"
+                },
+                {
+                    "begin": "(?<=\\])(\\{)",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
                     "patterns": [
                         {
-                            "begin": "\\G",
-                            "end": "(\\])(?=\\{)",
-                            "endCaptures": {
-                                "1": {
-                                    "name": "punctuation.definition.arguments.optional.end.latex"
-                                }
-                            },
-                            "patterns": [
-                                {
-                                    "include": "text.tex#braces"
-                                },
-                                {
-                                    "include": "$base"
-                                }
-                            ]
-                        },
-                        {
-                            "begin": "(?<=\\])(\\{)",
-                            "end": "(?=\\})",
-                            "beginCaptures": {
-                                "0": {
-                                    "name": "punctuation.definition.arguments.begin.latex"
-                                }
-                            },
-                            "contentName": "meta.function.embedded.latex",
-                            "name": "meta.embedded.block.generic.latex"
+                            "include": "text.tex#braces"
                         }
-                    ]
+                    ],
+                    "name": "meta.embedded.block.generic.latex"
                 }
             ]
         },

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -1949,6 +1949,58 @@
             ]
         },
         {
+            "begin": "((\\\\)cacheMeCode(?=\\[))",
+            "end": "(?<=\\})",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.verb.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "\\[",
+                    "end": "\\]",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.optional.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.optional.end.latex"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "text.tex#braces"
+                        },
+                        {
+                            "include": "$base"
+                        }
+                    ]
+                },
+                {
+                    "begin": "(?<=\\])\\{",
+                    "end": "\\}",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        }
+                    },
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "meta.function.embedded.latex",
+                    "name": "meta.embedded.block.generic.latex"
+                }
+            ]
+        },
+        {
             "begin": "((\\\\)addplot)(?:\\+?)((?:\\[[^\\[]*\\]))*\\s*(gnuplot)\\s*((?:\\[[^\\[]*\\]))*\\s*(\\{)",
             "captures": {
                 "1": {


### PR DESCRIPTION
This is a follow-up on #79  to close #77. 

This PR adds support for `\cacheMeCode[options]{code}`. Both the content of `[]` and `{}` can span over several lines. 

@dflvunoooooo @tobiasBora Currently the code part is considered as verbatim. Would it make sense to support embedded language and if so how can it be inferred from the optional argument?