### PR TITLE
Highlight LaTeX 3 quarks & scan marks (\q_xxx & \s_xxx)

### DIFF
--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -793,7 +793,7 @@ patterns:
 - captures:
     '1':
       name: punctuation.definition.variable.latex
-  match: (\\)(?:[cgl](?:[_\p{Alphabetic}@]+)+_[a-z]+|[qs](?:[_\p{Alphabetic}@]+)*_[\p{Alphabetic}@]+)
+  match: (\\)(?:[cgl]_+[_\p{Alphabetic}@]+_[a-z]+|[qs]_[_\p{Alphabetic}@]+[\p{Alphabetic}@])
   name: variable.other.latex3.latex
 - captures:
     '1':

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -793,7 +793,7 @@ patterns:
 - captures:
     '1':
       name: punctuation.definition.variable.latex
-  match: (\\)[cgl](?:[_\p{Alphabetic}@]+)+_[a-z]+
+  match: (\\)(?:[cgl](?:[_\p{Alphabetic}@]+)+_[a-z]+|[qs](?:[_\p{Alphabetic}@]+)*_[\p{Alphabetic}@]+)
   name: variable.other.latex3.latex
 - captures:
     '1':

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -3104,7 +3104,7 @@
                             "name": "punctuation.definition.variable.latex"
                         }
                     },
-                    "match": "(\\\\)(?:[cgl](?:[_\\p{Alphabetic}@]+)+_[a-z]+|[qs](?:[_\\p{Alphabetic}@]+)*_[\\p{Alphabetic}@]+)",
+                    "match": "(\\\\)(?:[cgl]_+[_\\p{Alphabetic}@]+_[a-z]+|[qs]_[_\\p{Alphabetic}@]+[\\p{Alphabetic}@])",
                     "name": "variable.other.latex3.latex"
                 },
                 {

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -3104,7 +3104,7 @@
                             "name": "punctuation.definition.variable.latex"
                         }
                     },
-                    "match": "(\\\\)[cgl](?:[_\\p{Alphabetic}@]+)+_[a-z]+",
+                    "match": "(\\\\)(?:[cgl](?:[_\\p{Alphabetic}@]+)+_[a-z]+|[qs](?:[_\\p{Alphabetic}@]+)*_[\\p{Alphabetic}@]+)",
                     "name": "variable.other.latex3.latex"
                 },
                 {

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -3043,7 +3043,7 @@
                     "name": "punctuation.definition.variable.latex"
                 }
             },
-            "match": "(\\\\)(?:[cgl](?:[_\\p{Alphabetic}@]+)+_[a-z]+|[qs](?:[_\\p{Alphabetic}@]+)*_[\\p{Alphabetic}@]+)",
+            "match": "(\\\\)(?:[cgl]_+[_\\p{Alphabetic}@]+_[a-z]+|[qs]_[_\\p{Alphabetic}@]+[\\p{Alphabetic}@])",
             "name": "variable.other.latex3.latex"
         },
         {

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -3043,7 +3043,7 @@
                     "name": "punctuation.definition.variable.latex"
                 }
             },
-            "match": "(\\\\)[cgl](?:[_\\p{Alphabetic}@]+)+_[a-z]+",
+            "match": "(\\\\)(?:[cgl](?:[_\\p{Alphabetic}@]+)+_[a-z]+|[qs](?:[_\\p{Alphabetic}@]+)*_[\\p{Alphabetic}@]+)",
             "name": "variable.other.latex3.latex"
         },
         {

--- a/test/colorize-fixtures/basic-commands.tex
+++ b/test/colorize-fixtures/basic-commands.tex
@@ -32,4 +32,37 @@ and more text''
 
 Some texte with `a single' quote.
 
+\ExplSyntaxOn
+\c__
+\s__
+
+\c_tmpa_tl
+\g_tmpa_tl
+\l_tmpa_tl
+\l__mymod_tmp_cctab
+\l_@@_prop
+\l_@@_tmp_bitsec
+\q_mark
+\q_no_value
+\s_stop
+\s__quark
+\s__mymod_tmp_mark
+\s_@@
+\s_@@_mark
+
+\c___tl
+\c___mymod_tl
+\s___mymod_mark
+
+\tl_set:Nn
+\tl_if_empty:NTF
+\tl_if_empty_p:N
+\cs_new:Npn
+\__kernel_chk_if_free_cs:N
+\tex_relax:D
+\mymod_all_arg_types:cVvoxef
+\__mymod_fun:
+\@@_fun:
+\ExplSyntaxOff
+
 \end{document}

--- a/test/colorize-results/basic-commands_tex.json
+++ b/test/colorize-results/basic-commands_tex.json
@@ -721,6 +721,246 @@
 	},
 	{
 		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ExplSyntaxOn",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "c",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "__",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "s",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "__",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "c_tmpa_tl",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "g_tmpa_tl",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "l_tmpa_tl",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "l__mymod_tmp_cctab",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "l_@@_prop",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "l_@@_tmp_bitsec",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "q_mark",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "q_no_value",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "s_stop",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "s__quark",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "s__mymod_tmp_mark",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "s_@@",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "s_@@_mark",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "c___tl",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "c___mymod_tl",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex variable.other.latex3.latex punctuation.definition.variable.latex"
+	},
+	{
+		"c": "s___mymod_mark",
+		"t": "text.tex.latex variable.other.latex3.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "tl_set:Nn",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "tl_if_empty:NTF",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "tl_if_empty_p:N",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "cs_new:Npn",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "__kernel_chk_if_free_cs:N",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "tex_relax:D",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "mymod_all_arg_types:cVvoxef",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "__mymod_fun:",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@@_fun:",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ExplSyntaxOff",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
 		"t": "text.tex.latex meta.function.end-document.latex support.function.be.latex punctuation.definition.function.latex"
 	},
 	{


### PR DESCRIPTION
From `texdoc interface3`, chap. 19,

> Two special types of constants in LaTeX3 are “quarks” and “scan marks”. By convention all constants of type quark start out with `\q_`, and scan marks start with `\s_`.

Note that quark and scan mark variables do not end with a type name, so they can have only one name part joint by underscores, like `\q_stop` and `\s_stop`.

BTW, how to update generated results in `test/colorize-results`? I would like to add some tests for LaTeX3 commands, for example to `test/colorize-fixtures/basic-commands.tex`.