### PR TITLE
Improve \iffalse...\fi detection

### DIFF
--- a/src/TeX.tmLanguage.yaml
+++ b/src/TeX.tmLanguage.yaml
@@ -7,7 +7,7 @@ patterns:
     '2':
       name: punctuation.definition.keyword.tex
   contentName: comment.line.percentage.tex
-  end: (?<=^\s*)((\\)(?:else|fi))
+  end: ((\\)(?:else|fi))
   endCaptures:
     '1':
       name: keyword.control.tex
@@ -15,6 +15,7 @@ patterns:
       name: punctuation.definition.keyword.tex
   patterns:
   - include: '#comment'
+  - include: "#braces"
   - include: '#conditionals'
 - captures:
     '1':

--- a/src/TeX.tmLanguage.yaml
+++ b/src/TeX.tmLanguage.yaml
@@ -1,6 +1,6 @@
 name: TeX
 patterns:
-- begin: (?<=^\s*)((\\)iffalse)
+- begin: (?<=^\s*)((\\)iffalse)(?!\s*[{}]\s*\\fi)
   beginCaptures:
     '1':
       name: keyword.control.tex

--- a/syntaxes/TeX.tmLanguage.json
+++ b/syntaxes/TeX.tmLanguage.json
@@ -12,7 +12,7 @@
                 }
             },
             "contentName": "comment.line.percentage.tex",
-            "end": "(?<=^\\s*)((\\\\)(?:else|fi))",
+            "end": "((\\\\)(?:else|fi))",
             "endCaptures": {
                 "1": {
                     "name": "keyword.control.tex"
@@ -24,6 +24,9 @@
             "patterns": [
                 {
                     "include": "#comment"
+                },
+                {
+                    "include": "#braces"
                 },
                 {
                     "include": "#conditionals"

--- a/syntaxes/TeX.tmLanguage.json
+++ b/syntaxes/TeX.tmLanguage.json
@@ -2,7 +2,7 @@
     "name": "TeX",
     "patterns": [
         {
-            "begin": "(?<=^\\s*)((\\\\)iffalse)",
+            "begin": "(?<=^\\s*)((\\\\)iffalse)(?!\\s*[{}]\\s*\\\\fi)",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.control.tex"

--- a/test/colorize-fixtures/iffalse.tex
+++ b/test/colorize-fixtures/iffalse.tex
@@ -42,3 +42,22 @@ poo
 %\fi
 and more
 \fi
+
+% #97, skip brace tricks
+% array.sty v2.6d (2024/06/14), line 229-232
+\protected\def\@arraycr {
+  \tbl_count_missing_cells:n {@arraycr}
+  \iffalse{\fi\ifnum 0=`}\fi
+  \@ifstar \@xarraycr \@xarraycr}
+
+% From https://github.com/texstudio-org/texstudio/issues/618#issuecomment-499325441
+\def\newif#1{%
+  \count@\escapechar \escapechar\m@ne
+    \let#1\iffalse
+    \@if#1\iftrue
+    \@if#1\iffalse
+  \escapechar\count@}
+
+\def\environment{\begingroup
+   \catcode`\\12
+   \MakePrivateLetters \m@cro@ \iffalse}

--- a/test/colorize-fixtures/iffalse.tex
+++ b/test/colorize-fixtures/iffalse.tex
@@ -61,3 +61,32 @@ and more
 \def\environment{\begingroup
    \catcode`\\12
    \MakePrivateLetters \m@cro@ \iffalse}
+
+% #97 skip \iffalse}\fi and \iffalse{\fi
+\def\bbgroup{{\iffalse}\fi}
+\def\eegroup{\iffalse{\fi}text text}
+
+\def\bbgroup{{%
+  \iffalse}\fi}
+\def\eegroup{%
+  \iffalse{\fi}%
+  text text}
+
+\renewcommand\ensureTABstackMath[1]{%
+\iffalse{\fi
+\let\sv@TABmode\TAB@delim\TABstackMath#1\let\TAB@delim\sv@TABmode
+\iffalse}\fi
+}
+
+% From tex/latex/bigfoot/bigfoot.sty:192
+\def\PopFootnoteMark#1{\expandafter
+  \ifx\csname FN@stack@#1\endcsname\@empty
+    \PackageError{bigfoot}{Empty footnote stack #1}%
+    {The specified footnote type has no uncompleted range}%
+  \else
+  {\let\@elt\FN@firstpop
+    \iffalse{\fi\csname FN@stack@#1\endcsname}}\fi}
+\def\FN@firstpop#1#2#3{\protected@xdef\@thefnmark{#2}%
+  \let\@elt\relax
+  \expandafter\protected@xdef\csname FN@stack@#1\endcsname{%
+    \iffalse}\fi}

--- a/test/colorize-results/iffalse_tex.json
+++ b/test/colorize-results/iffalse_tex.json
@@ -313,15 +313,31 @@
 	},
 	{
 		"c": "{",
-		"t": "text.tex.latex comment.line.percentage.tex meta.group.braces.tex punctuation.group.begin.tex"
+		"t": "text.tex.latex"
 	},
 	{
-		"c": "\\fi\\ifnum 0=`",
-		"t": "text.tex.latex comment.line.percentage.tex meta.group.braces.tex"
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
 	},
 	{
-		"c": "}",
-		"t": "text.tex.latex comment.line.percentage.tex meta.group.braces.tex punctuation.group.end.tex"
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "ifnum",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex meta.space-after-command.latex"
+	},
+	{
+		"c": "0=`}",
+		"t": "text.tex.latex"
 	},
 	{
 		"c": "\\",
@@ -625,6 +641,718 @@
 	},
 	{
 		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " #97 skip \\iffalse}\\fi and \\iffalse{\\fi",
+		"t": "text.tex.latex comment.line.percentage.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "bbgroup",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "{{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "eegroup",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}text text}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "bbgroup",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "{{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "eegroup",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  text text}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "renewcommand",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ensureTABstackMath",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.latex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.latex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "let",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "sv@TABmode",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "TAB@delim",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "TABstackMath",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "#1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "let",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "TAB@delim",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "sv@TABmode",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " From tex/latex/bigfoot/bigfoot.sty:192",
+		"t": "text.tex.latex comment.line.percentage.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "PopFootnoteMark",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "#1{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "expandafter",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "ifx",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "csname",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex meta.space-after-command.latex"
+	},
+	{
+		"c": "FN@stack@#1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "endcsname",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@empty",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "PackageError",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "{bigfoot}{Empty footnote stack #1}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "    {The specified footnote type has no uncompleted range}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "else",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "  {",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "let",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@elt",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "FN@firstpop",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "csname",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex meta.space-after-command.latex"
+	},
+	{
+		"c": "FN@stack@#1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "endcsname",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "FN@firstpop",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "#1#2#3{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "protected@xdef",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@thefnmark",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "{#2}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "let",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@elt",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "relax",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "expandafter",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "protected@xdef",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "csname",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex meta.space-after-command.latex"
+	},
+	{
+		"c": "FN@stack@#1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "endcsname",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
 		"t": "text.tex.latex keyword.control.tex"
 	},
 	{

--- a/test/colorize-results/iffalse_tex.json
+++ b/test/colorize-results/iffalse_tex.json
@@ -238,5 +238,397 @@
 	{
 		"c": "fi",
 		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " #97, skip brace tricks",
+		"t": "text.tex.latex comment.line.percentage.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " array.sty v2.6d (2024/06/14), line 229-232",
+		"t": "text.tex.latex comment.line.percentage.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "protected",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@arraycr",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": " {",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.class.general.latex3.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "tbl_count_missing_cells:n",
+		"t": "text.tex.latex support.class.general.latex3.tex"
+	},
+	{
+		"c": " {@arraycr}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex comment.line.percentage.tex meta.group.braces.tex punctuation.group.begin.tex"
+	},
+	{
+		"c": "\\fi\\ifnum 0=`",
+		"t": "text.tex.latex comment.line.percentage.tex meta.group.braces.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex comment.line.percentage.tex meta.group.braces.tex punctuation.group.end.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@ifstar",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@xarraycr",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@xarraycr",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " From https://github.com/texstudio-org/texstudio/issues/618#issuecomment-499325441",
+		"t": "text.tex.latex comment.line.percentage.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newif",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "#1{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "count@",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "escapechar",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "escapechar",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "m@ne",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "let",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "#1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@if",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "#1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iftrue",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@if",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "#1",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "escapechar",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "count@",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "environment",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "begingroup",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "   ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "catcode",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": "`",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\\\",
+		"t": "text.tex.latex keyword.control.newline.tex"
+	},
+	{
+		"c": "12",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "   ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "MakePrivateLetters",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "m@cro@",
+		"t": "text.tex.latex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex meta.space-after-command.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.latex keyword.control.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex"
 	}
 ]


### PR DESCRIPTION
Close #97

Currently, `\iffalse...\fi` blocks are detected only if they start at the beginning of a line or are only preceded by spaces.

This PR skips any `{...}` block after a `\iffalse` to avoid wrong end detection. This should fix issues with code like

```tex
% array.sty v2.6d (2024/06/14), line 229-232
\protected\def\@arraycr {
  \tbl_count_missing_cells:n {@arraycr}
  \iffalse{\fi\ifnum 0=`}\fi
  \@ifstar \@xarraycr \@xarraycr}
```