### PR TITLE
Declare some language ids as internal only

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Since textmate grammars are purely static, it is not possible to inject new rule
 
 The starred version of the environments are also recognized.
 
+## Internal only languages
+
+### Combined LaTeX/Markdown grammar
+
+The combined Markdown/LaTeX grammar [syntaxes/markdown-latex-combined.tmLanguage.json](syntaxes/markdown-latex-combined.tmLanguage.json) is designed to match the code inside the `markdown` environment in LaTeX files, which accepts both LaTeX and Markdown instructions.
+
+### C++ bailed out grammar
+
+The C++ bailed out grammar [syntaxes/cpp-grammar-bailout.tmLanguage.json](syntaxes/cpp-grammar-bailout.tmLanguage.json) is used for C/C++ code blocks inside LaTeX files.
+
 ## License
 
 If not otherwise specified (see below), files in this repository fall under the license stated in [LICENSE.txt](LICENSE.txt)

--- a/build/latex-md.mjs
+++ b/build/latex-md.mjs
@@ -38,7 +38,7 @@ export function latexMd() {
     console.log('Generating markdown-latex grammar')
     insertLaTeXGrammar('https://raw.githubusercontent.com/microsoft/vscode/main/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json',
         'text.tex.latex',
-        'text.tex.markdown_latex_combined',
+        'text.tex.internal_only_markdown_latex_combined',
         './syntaxes/markdown-latex-combined.tmLanguage.json'
     )
     expandConfigurationFile('./src/markdown-latex-combined.language-configuration.json', './languages/markdown-latex-combined-language-configuration.json')

--- a/package.json
+++ b/package.json
@@ -127,11 +127,11 @@
         "configuration": "./languages/latex-language-configuration.json"
       },
       {
-        "id": "cpp_embedded_latex",
+        "id": "internal_only_cpp_embedded_latex",
         "configuration": "./languages/latex-cpp-embedded-language-configuration.json"
       },
       {
-        "id": "markdown_latex_combined",
+        "id": "internal_only_markdown_latex_combined",
         "configuration": "./languages/markdown-latex-combined-language-configuration.json"
       }
     ],
@@ -152,7 +152,7 @@
         "path": "./syntaxes/LaTeX.tmLanguage.json",
         "embeddedLanguages": {
           "source.asymptote": "asymptote",
-          "source.cpp": "cpp_embedded_latex",
+          "source.cpp": "internal_only_cpp_embedded_latex",
           "source.css": "css",
           "source.dot": "dot",
           "source.gnuplot": "gnuplot",
@@ -167,7 +167,7 @@
           "source.ts": "typescript",
           "text.xml": "xml",
           "source.yaml": "yaml",
-          "meta.embedded.markdown_latex_combined": "markdown_latex_combined"
+          "meta.embedded.internal_only_markdown_latex_combined": "internal_only_markdown_latex_combined"
         }
       },
       {
@@ -181,12 +181,12 @@
         "path": "./syntaxes/BibTeX-style.tmLanguage.json"
       },
       {
-        "language": "markdown_latex_combined",
-        "scopeName": "text.tex.markdown_latex_combined",
+        "language": "internal_only_markdown_latex_combined",
+        "scopeName": "text.tex.internal_only_markdown_latex_combined",
         "path": "./syntaxes/markdown-latex-combined.tmLanguage.json"
       },
       {
-        "language": "cpp_embedded_latex",
+        "language": "internal_only_cpp_embedded_latex",
         "scopeName": "source.cpp.embedded.latex",
         "path": "./syntaxes/cpp-grammar-bailout.tmLanguage.json",
         "embeddedLanguages": {

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -375,10 +375,10 @@ patterns:
     '1':
       patterns:
       - include: '#begin-env-tokenizer'
-  contentName: meta.embedded.markdown_latex_combined
+  contentName: meta.embedded.internal_only_markdown_latex_combined
   end: (\\end\{markdown\})
   patterns:
-  - include: text.tex.markdown_latex_combined
+  - include: text.tex.internal_only_markdown_latex_combined
 - begin: (\s*\\begin\{(\w+\*?)\})
   captures:
     '1':

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -2403,11 +2403,11 @@
                             ]
                         }
                     },
-                    "contentName": "meta.embedded.markdown_latex_combined",
+                    "contentName": "meta.embedded.internal_only_markdown_latex_combined",
                     "end": "(\\\\end\\{markdown\\})",
                     "patterns": [
                         {
-                            "include": "text.tex.markdown_latex_combined"
+                            "include": "text.tex.internal_only_markdown_latex_combined"
                         }
                     ]
                 },

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -2342,11 +2342,11 @@
                     ]
                 }
             },
-            "contentName": "meta.embedded.markdown_latex_combined",
+            "contentName": "meta.embedded.internal_only_markdown_latex_combined",
             "end": "(\\\\end\\{markdown\\})",
             "patterns": [
                 {
-                    "include": "text.tex.markdown_latex_combined"
+                    "include": "text.tex.internal_only_markdown_latex_combined"
                 }
             ]
         },

--- a/syntaxes/markdown-latex-combined.tmLanguage.json
+++ b/syntaxes/markdown-latex-combined.tmLanguage.json
@@ -6,7 +6,7 @@
 	],
 	"version": "https://github.com/microsoft/vscode-markdown-tm-grammar/commit/7418dd20d76c72e82fadee2909e03239e9973b35",
 	"name": "Markdown",
-	"scopeName": "text.tex.markdown_latex_combined",
+	"scopeName": "text.tex.internal_only_markdown_latex_combined",
 	"patterns": [
 		{
 			"include": "text.tex.latex"

--- a/test/colorize-results/basic-envs_tex.json
+++ b/test/colorize-results/basic-envs_tex.json
@@ -569,75 +569,75 @@
 	},
 	{
 		"c": "  some markdown ",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown"
 	},
 	{
 		"c": "_",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown"
 	},
 	{
 		"c": "code",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown markup.italic.markdown"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown markup.italic.markdown"
 	},
 	{
 		"c": "_",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown"
 	},
 	{
 		"c": "  with a ",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown"
 	},
 	{
 		"c": "\\",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown support.function.general.tex punctuation.definition.function.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown support.function.general.tex punctuation.definition.function.tex"
 	},
 	{
 		"c": "LaTeX",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown support.function.general.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown support.function.general.tex"
 	},
 	{
 		"c": " ",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.space-after-command.latex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.space-after-command.latex"
 	},
 	{
 		"c": "equation ",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown"
 	},
 	{
 		"c": "$",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex punctuation.definition.string.begin.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex punctuation.definition.string.begin.tex"
 	},
 	{
 		"c": "1",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex constant.numeric.math.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex constant.numeric.math.tex"
 	},
 	{
 		"c": " ",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex"
 	},
 	{
 		"c": "+",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex punctuation.math.operator.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex punctuation.math.operator.tex"
 	},
 	{
 		"c": "2",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex constant.numeric.math.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex constant.numeric.math.tex"
 	},
 	{
 		"c": " = ",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex"
 	},
 	{
 		"c": "3",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex constant.numeric.math.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex constant.numeric.math.tex"
 	},
 	{
 		"c": "$",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex punctuation.definition.string.end.tex"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown meta.math.block.tex support.class.math.block.tex punctuation.definition.string.end.tex"
 	},
 	{
 		"c": ".",
-		"t": "text.tex.latex meta.embedded.markdown_latex_combined meta.paragraph.markdown"
+		"t": "text.tex.latex meta.embedded.internal_only_markdown_latex_combined meta.paragraph.markdown"
 	},
 	{
 		"c": "\\",


### PR DESCRIPTION
Related to https://github.com/James-Yu/LaTeX-Workshop/issues/4533

The two grammars `markdown_latex_combined` and `cpp_embedded_latex` are designed to be used only in embedded block. With this PR, their names are prefixed with `internal_only_`.