### PR TITLE
Improve Songs package - correct chord highlighting for separate files

### DIFF
--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -81,6 +81,29 @@ patterns:
   - match: \^
     name: meta.chord.block.latex support.class.chord.block.environment.latex
   - include: $self
+- comment: This scope applies songs-environment coloring between \\beginsong and \\endsong. Useful in separate files without \\begin{songs}.
+  begin: ((?:\s*)(\\)beginsong)(\{).*?(\})
+  captures:
+    '1':
+      name: support.function.be.latex
+    '2':
+      name: punctuation.definition.function.latex
+    '3':
+      name: punctuation.definition.arguments.begin.latex
+    '4':
+      name: punctuation.definition.arguments.end.latex
+  contentName: meta.data.environment.songs.latex
+  end: ((\\)endsong)(?:\s*\n)?
+  name: meta.function.environment.songs.latex
+  patterns:
+  - begin: \\\[
+    end: \]
+    name: meta.chord.block.latex support.class.chord.block.environment.latex
+    patterns:
+    - include: $self
+  - match: \^
+    name: meta.chord.block.latex support.class.chord.block.environment.latex
+  - include: $self
 - begin: (?:^\s*)?\\begin\{(lstlisting|minted|pyglist)\}(?=\[|\{)
   captures:
     '0':

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -86,13 +86,13 @@ patterns:
     '4':
       name: punctuation.definition.arguments.end.latex
   end: ((\\)endsong)(?:\s*\n)?
+  name: meta.function.environment.song.latex
   patterns:
   - include: '#multiline-arg-no-highlight'
   - include: '#multiline-optional-arg-no-highlight'
   - begin: (?:\G|(?<=\]|\}))(\s*)
     end: \s*(?=\\endsong)
     contentName: meta.data.environment.song.latex
-    name: meta.function.environment.song.latex
     patterns:
     - include: text.tex.latex#songs-chords
 - begin: (?:^\s*)?\\begin\{(lstlisting|minted|pyglist)\}(?=\[|\{)

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -64,7 +64,7 @@ patterns:
   patterns:
   - include: text.tex#braces
   - include: $self
-- begin: ((?:\s*)\\begin\{songs\}\{.*\})
+- begin: (\s*\\begin\{songs\}\{.*\})
   captures:
     '1':
       patterns:
@@ -75,7 +75,7 @@ patterns:
   patterns:
   - include: text.tex.latex#songs-chords
 - comment: This scope applies songs-environment coloring between \\beginsong and \\endsong. Useful in separate files without \\begin{songs}.
-  begin: ((?:\s*)(\\)beginsong)(?=\{)
+  begin: \s*((\\)beginsong)(?=\{)
   captures:
     '1':
       name: support.function.be.latex
@@ -90,7 +90,7 @@ patterns:
   patterns:
   - include: '#multiline-arg-no-highlight'
   - include: '#multiline-optional-arg-no-highlight'
-  - begin: (?:\G|(?<=\]|\}))(\s*)
+  - begin: (?:\G|(?<=\]|\}))\s*
     end: \s*(?=\\endsong)
     contentName: meta.data.environment.song.latex
     patterns:

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -73,16 +73,9 @@ patterns:
   end: (\\end\{songs\}(?:\s*\n)?)
   name: meta.function.environment.songs.latex
   patterns:
-  - begin: \\\[
-    end: \]
-    name: meta.chord.block.latex support.class.chord.block.environment.latex
-    patterns:
-    - include: $self
-  - match: \^
-    name: meta.chord.block.latex support.class.chord.block.environment.latex
-  - include: $self
+  - include: text.tex.latex#songs-chords
 - comment: This scope applies songs-environment coloring between \\beginsong and \\endsong. Useful in separate files without \\begin{songs}.
-  begin: ((?:\s*)(\\)beginsong)(\{).*?(\})
+  begin: ((?:\s*)(\\)beginsong)(?=\{)
   captures:
     '1':
       name: support.function.be.latex
@@ -92,18 +85,16 @@ patterns:
       name: punctuation.definition.arguments.begin.latex
     '4':
       name: punctuation.definition.arguments.end.latex
-  contentName: meta.data.environment.songs.latex
   end: ((\\)endsong)(?:\s*\n)?
-  name: meta.function.environment.songs.latex
   patterns:
-  - begin: \\\[
-    end: \]
-    name: meta.chord.block.latex support.class.chord.block.environment.latex
+  - include: '#multiline-arg-no-highlight'
+  - include: '#multiline-optional-arg-no-highlight'
+  - begin: ^(?=\\s*)
+    end: ^\s*(?=\\endsong)
+    contentName: meta.data.environment.song.latex
+    name: meta.function.environment.song.latex
     patterns:
-    - include: $self
-  - match: \^
-    name: meta.chord.block.latex support.class.chord.block.environment.latex
-  - include: $self
+    - include: text.tex.latex#songs-chords
 - begin: (?:^\s*)?\\begin\{(lstlisting|minted|pyglist)\}(?=\[|\{)
   captures:
     '0':
@@ -906,7 +897,7 @@ repository:
     patterns:
     - include: $self
   multiline-optional-arg-no-highlight:
-    begin: \G\[
+    begin: (?:\G|(?<=\}))\s*\[
     beginCaptures:
       '0':
         name: punctuation.definition.arguments.optional.begin.latex
@@ -915,6 +906,18 @@ repository:
       '0':
         name: punctuation.definition.arguments.optional.end.latex
     name: meta.parameter.optional.latex
+    patterns:
+    - include: $self
+  multiline-arg-no-highlight:
+    begin: \G\{
+    beginCaptures:
+      '0':
+        name: punctuation.definition.arguments.begin.latex
+    end: \}
+    endCaptures:
+      '0':
+        name: punctuation.definition.arguments.end.latex
+    name: meta.parameter.latex
     patterns:
     - include: $self
   optional-arg-bracket:
@@ -966,4 +969,14 @@ repository:
           name: punctuation.definition.arguments.optional.end.latex
       match: (\()[^\(]*?(\))
       name: meta.parameter.optional.latex
+  songs-chords:
+    patterns:
+    - begin: \\\[
+      end: \]
+      name: meta.chord.block.latex support.class.chord.block.environment.latex
+      patterns:
+      - include: $self
+    - match: \^
+      name: meta.chord.block.latex support.class.chord.block.environment.latex
+    - include: $self
 scopeName: text.tex.latex

--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -89,8 +89,8 @@ patterns:
   patterns:
   - include: '#multiline-arg-no-highlight'
   - include: '#multiline-optional-arg-no-highlight'
-  - begin: ^(?=\\s*)
-    end: ^\s*(?=\\endsong)
+  - begin: (?:\G|(?<=\]|\}))(\s*)
+    end: \s*(?=\\endsong)
     contentName: meta.data.environment.song.latex
     name: meta.function.environment.song.latex
     patterns:

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -190,27 +190,13 @@
                     "name": "meta.function.environment.songs.latex",
                     "patterns": [
                         {
-                            "begin": "\\\\\\[",
-                            "end": "\\]",
-                            "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
-                            "patterns": [
-                                {
-                                    "include": "$self"
-                                }
-                            ]
-                        },
-                        {
-                            "match": "\\^",
-                            "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
-                        },
-                        {
-                            "include": "$self"
+                            "include": "text.tex.latex#songs-chords"
                         }
                     ]
                 },
                 {
-                    "comment": "This scope applies songs-environment coloring between \\beginsong and \\endsong. Useful in separate files without \\begin{songs}.",
-                    "begin": "((?:\\s*)(\\\\)beginsong)(\\{).*?(\\})",
+                    "comment": "This scope applies songs-environment coloring between \\\\beginsong and \\\\endsong. Useful in separate files without \\\\begin{songs}.",
+                    "begin": "((?:\\s*)(\\\\)beginsong)(?=\\{)",
                     "captures": {
                         "1": {
                             "name": "support.function.be.latex"
@@ -225,26 +211,24 @@
                             "name": "punctuation.definition.arguments.end.latex"
                         }
                     },
-                    "contentName": "meta.data.environment.songs.latex",
                     "end": "((\\\\)endsong)(?:\\s*\\n)?",
-                    "name": "meta.function.environment.songs.latex",
                     "patterns": [
                         {
-                            "begin": "\\\\\\[",
-                            "end": "\\]",
-                            "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
+                            "include": "#multiline-arg-no-highlight"
+                        },
+                        {
+                            "include": "#multiline-optional-arg-no-highlight"
+                        },
+                        {
+                            "begin": "^(?=\\\\s*)",
+                            "end": "^\\s*(?=\\\\endsong)",
+                            "contentName": "meta.data.environment.song.latex",
+                            "name": "meta.function.environment.song.latex",
                             "patterns": [
                                 {
-                                    "include": "$self"
+                                    "include": "text.tex.latex#songs-chords"
                                 }
                             ]
-                        },
-                        {
-                            "match": "\\^",
-                            "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
-                        },
-                        {
-                            "include": "$self"
                         }
                     ]
                 },
@@ -3344,7 +3328,7 @@
             ]
         },
         "multiline-optional-arg-no-highlight": {
-            "begin": "\\G\\[",
+            "begin": "(?:\\G|(?<=\\}))\\s*\\[",
             "beginCaptures": {
                 "0": {
                     "name": "punctuation.definition.arguments.optional.begin.latex"
@@ -3357,6 +3341,26 @@
                 }
             },
             "name": "meta.parameter.optional.latex",
+            "patterns": [
+                {
+                    "include": "$self"
+                }
+            ]
+        },
+        "multiline-arg-no-highlight": {
+            "begin": "\\G\\{",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.arguments.begin.latex"
+                }
+            },
+            "end": "\\}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.arguments.end.latex"
+                }
+            },
+            "name": "meta.parameter.latex",
             "patterns": [
                 {
                     "include": "$self"
@@ -3446,6 +3450,27 @@
                     },
                     "match": "(\\()[^\\(]*?(\\))",
                     "name": "meta.parameter.optional.latex"
+                }
+            ]
+        },
+        "songs-chords": {
+            "patterns": [
+                {
+                    "begin": "\\\\\\[",
+                    "end": "\\]",
+                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
+                    "patterns": [
+                        {
+                            "include": "$self"
+                        }
+                    ]
+                },
+                {
+                    "match": "\\^",
+                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
+                },
+                {
+                    "include": "$self"
                 }
             ]
         }

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -175,7 +175,7 @@
                     ]
                 },
                 {
-                    "begin": "((?:\\s*)\\\\begin\\{songs\\}\\{.*\\})",
+                    "begin": "(\\s*\\\\begin\\{songs\\}\\{.*\\})",
                     "captures": {
                         "1": {
                             "patterns": [
@@ -196,7 +196,7 @@
                 },
                 {
                     "comment": "This scope applies songs-environment coloring between \\\\beginsong and \\\\endsong. Useful in separate files without \\\\begin{songs}.",
-                    "begin": "((?:\\s*)(\\\\)beginsong)(?=\\{)",
+                    "begin": "\\s*((\\\\)beginsong)(?=\\{)",
                     "captures": {
                         "1": {
                             "name": "support.function.be.latex"
@@ -221,7 +221,7 @@
                             "include": "#multiline-optional-arg-no-highlight"
                         },
                         {
-                            "begin": "(?:\\G|(?<=\\]|\\}))(\\s*)",
+                            "begin": "(?:\\G|(?<=\\]|\\}))\\s*",
                             "end": "\\s*(?=\\\\endsong)",
                             "contentName": "meta.data.environment.song.latex",
                             "patterns": [

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -220,8 +220,8 @@
                             "include": "#multiline-optional-arg-no-highlight"
                         },
                         {
-                            "begin": "^(?=\\\\s*)",
-                            "end": "^\\s*(?=\\\\endsong)",
+                            "begin": "(?:\\G|(?<=\\]|\\}))(\\s*)",
+                            "end": "\\s*(?=\\\\endsong)",
                             "contentName": "meta.data.environment.song.latex",
                             "name": "meta.function.environment.song.latex",
                             "patterns": [

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -212,6 +212,7 @@
                         }
                     },
                     "end": "((\\\\)endsong)(?:\\s*\\n)?",
+                    "name": "meta.function.environment.song.latex",
                     "patterns": [
                         {
                             "include": "#multiline-arg-no-highlight"
@@ -223,7 +224,6 @@
                             "begin": "(?:\\G|(?<=\\]|\\}))(\\s*)",
                             "end": "\\s*(?=\\\\endsong)",
                             "contentName": "meta.data.environment.song.latex",
-                            "name": "meta.function.environment.song.latex",
                             "patterns": [
                                 {
                                     "include": "text.tex.latex#songs-chords"

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -209,6 +209,46 @@
                     ]
                 },
                 {
+                    "comment": "This scope applies songs-environment coloring between \\beginsong and \\endsong. Useful in separate files without \\begin{songs}.",
+                    "begin": "((?:\\s*)(\\\\)beginsong)(\\{).*?(\\})",
+                    "captures": {
+                        "1": {
+                            "name": "support.function.be.latex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.function.latex"
+                        },
+                        "3": {
+                            "name": "punctuation.definition.arguments.begin.latex"
+                        },
+                        "4": {
+                            "name": "punctuation.definition.arguments.end.latex"
+                        }
+                    },
+                    "contentName": "meta.data.environment.songs.latex",
+                    "end": "((\\\\)endsong)(?:\\s*\\n)?",
+                    "name": "meta.function.environment.songs.latex",
+                    "patterns": [
+                        {
+                            "begin": "\\\\\\[",
+                            "end": "\\]",
+                            "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
+                            "patterns": [
+                                {
+                                    "include": "$self"
+                                }
+                            ]
+                        },
+                        {
+                            "match": "\\^",
+                            "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
+                        },
+                        {
+                            "include": "$self"
+                        }
+                    ]
+                },
+                {
                     "begin": "(?:^\\s*)?\\\\begin\\{(lstlisting|minted|pyglist)\\}(?=\\[|\\{)",
                     "captures": {
                         "0": {

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -151,6 +151,7 @@
                 }
             },
             "end": "((\\\\)endsong)(?:\\s*\\n)?",
+            "name": "meta.function.environment.song.latex",
             "patterns": [
                 {
                     "include": "#multiline-arg-no-highlight"
@@ -162,7 +163,6 @@
                     "begin": "(?:\\G|(?<=\\]|\\}))(\\s*)",
                     "end": "\\s*(?=\\\\endsong)",
                     "contentName": "meta.data.environment.song.latex",
-                    "name": "meta.function.environment.song.latex",
                     "patterns": [
                         {
                             "include": "text.tex.latex#songs-chords"

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -114,7 +114,7 @@
             ]
         },
         {
-            "begin": "((?:\\s*)\\\\begin\\{songs\\}\\{.*\\})",
+            "begin": "(\\s*\\\\begin\\{songs\\}\\{.*\\})",
             "captures": {
                 "1": {
                     "patterns": [
@@ -135,7 +135,7 @@
         },
         {
             "comment": "This scope applies songs-environment coloring between \\\\beginsong and \\\\endsong. Useful in separate files without \\\\begin{songs}.",
-            "begin": "((?:\\s*)(\\\\)beginsong)(?=\\{)",
+            "begin": "\\s*((\\\\)beginsong)(?=\\{)",
             "captures": {
                 "1": {
                     "name": "support.function.be.latex"
@@ -160,7 +160,7 @@
                     "include": "#multiline-optional-arg-no-highlight"
                 },
                 {
-                    "begin": "(?:\\G|(?<=\\]|\\}))(\\s*)",
+                    "begin": "(?:\\G|(?<=\\]|\\}))\\s*",
                     "end": "\\s*(?=\\\\endsong)",
                     "contentName": "meta.data.environment.song.latex",
                     "patterns": [

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -148,6 +148,46 @@
             ]
         },
         {
+            "comment": "This scope applies songs-environment coloring between \\beginsong and \\endsong. Useful in separate files without \\begin{songs}.",
+            "begin": "((?:\\s*)(\\\\)beginsong)(\\{).*?(\\})",
+            "captures": {
+                "1": {
+                    "name": "support.function.be.latex"
+                },
+                "2": {
+                    "name": "punctuation.definition.function.latex"
+                },
+                "3": {
+                    "name": "punctuation.definition.arguments.begin.latex"
+                },
+                "4": {
+                    "name": "punctuation.definition.arguments.end.latex"
+                }
+            },
+            "contentName": "meta.data.environment.songs.latex",
+            "end": "((\\\\)endsong)(?:\\s*\\n)?",
+            "name": "meta.function.environment.songs.latex",
+            "patterns": [
+                {
+                    "begin": "\\\\\\[",
+                    "end": "\\]",
+                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
+                    "patterns": [
+                        {
+                            "include": "$self"
+                        }
+                    ]
+                },
+                {
+                    "match": "\\^",
+                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
+                },
+                {
+                    "include": "$self"
+                }
+            ]
+        },
+        {
             "begin": "(?:^\\s*)?\\\\begin\\{(lstlisting|minted|pyglist)\\}(?=\\[|\\{)",
             "captures": {
                 "0": {

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -159,8 +159,8 @@
                     "include": "#multiline-optional-arg-no-highlight"
                 },
                 {
-                    "begin": "^(?=\\\\s*)",
-                    "end": "^\\s*(?=\\\\endsong)",
+                    "begin": "(?:\\G|(?<=\\]|\\}))(\\s*)",
+                    "end": "\\s*(?=\\\\endsong)",
                     "contentName": "meta.data.environment.song.latex",
                     "name": "meta.function.environment.song.latex",
                     "patterns": [

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -129,27 +129,13 @@
             "name": "meta.function.environment.songs.latex",
             "patterns": [
                 {
-                    "begin": "\\\\\\[",
-                    "end": "\\]",
-                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
-                    "patterns": [
-                        {
-                            "include": "$self"
-                        }
-                    ]
-                },
-                {
-                    "match": "\\^",
-                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
-                },
-                {
-                    "include": "$self"
+                    "include": "text.tex.latex#songs-chords"
                 }
             ]
         },
         {
-            "comment": "This scope applies songs-environment coloring between \\beginsong and \\endsong. Useful in separate files without \\begin{songs}.",
-            "begin": "((?:\\s*)(\\\\)beginsong)(\\{).*?(\\})",
+            "comment": "This scope applies songs-environment coloring between \\\\beginsong and \\\\endsong. Useful in separate files without \\\\begin{songs}.",
+            "begin": "((?:\\s*)(\\\\)beginsong)(?=\\{)",
             "captures": {
                 "1": {
                     "name": "support.function.be.latex"
@@ -164,26 +150,24 @@
                     "name": "punctuation.definition.arguments.end.latex"
                 }
             },
-            "contentName": "meta.data.environment.songs.latex",
             "end": "((\\\\)endsong)(?:\\s*\\n)?",
-            "name": "meta.function.environment.songs.latex",
             "patterns": [
                 {
-                    "begin": "\\\\\\[",
-                    "end": "\\]",
-                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
+                    "include": "#multiline-arg-no-highlight"
+                },
+                {
+                    "include": "#multiline-optional-arg-no-highlight"
+                },
+                {
+                    "begin": "^(?=\\\\s*)",
+                    "end": "^\\s*(?=\\\\endsong)",
+                    "contentName": "meta.data.environment.song.latex",
+                    "name": "meta.function.environment.song.latex",
                     "patterns": [
                         {
-                            "include": "$self"
+                            "include": "text.tex.latex#songs-chords"
                         }
                     ]
-                },
-                {
-                    "match": "\\^",
-                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
-                },
-                {
-                    "include": "$self"
                 }
             ]
         },
@@ -3283,7 +3267,7 @@
             ]
         },
         "multiline-optional-arg-no-highlight": {
-            "begin": "\\G\\[",
+            "begin": "(?:\\G|(?<=\\}))\\s*\\[",
             "beginCaptures": {
                 "0": {
                     "name": "punctuation.definition.arguments.optional.begin.latex"
@@ -3296,6 +3280,26 @@
                 }
             },
             "name": "meta.parameter.optional.latex",
+            "patterns": [
+                {
+                    "include": "$self"
+                }
+            ]
+        },
+        "multiline-arg-no-highlight": {
+            "begin": "\\G\\{",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.arguments.begin.latex"
+                }
+            },
+            "end": "\\}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.arguments.end.latex"
+                }
+            },
+            "name": "meta.parameter.latex",
             "patterns": [
                 {
                     "include": "$self"
@@ -3385,6 +3389,27 @@
                     },
                     "match": "(\\()[^\\(]*?(\\))",
                     "name": "meta.parameter.optional.latex"
+                }
+            ]
+        },
+        "songs-chords": {
+            "patterns": [
+                {
+                    "begin": "\\\\\\[",
+                    "end": "\\]",
+                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex",
+                    "patterns": [
+                        {
+                            "include": "$self"
+                        }
+                    ]
+                },
+                {
+                    "match": "\\^",
+                    "name": "meta.chord.block.latex support.class.chord.block.environment.latex"
+                },
+                {
+                    "include": "$self"
                 }
             ]
         }

--- a/test/colorize-fixtures/songs.tex
+++ b/test/colorize-fixtures/songs.tex
@@ -1,0 +1,37 @@
+\begin{songs}{}
+  \beginsong{Doxology}[by={Louis Bourgeois and Thomas Ken},
+  sr={Revelation 5:13},
+  cr={Public domain.}]
+  \beginverse
+  \[G]Praise God, \[D]from \[Em]Whom \[Bm]all \[Em]bless\[D]ings \[G]flow;
+  \[G]Praise Him, all \[D]crea\[Em]tures \[C]here \[G]be\[D]low;
+  \[Em]Praise \[D]Him \[G]a\[D]bove, \[G]ye \[C]heav’n\[D]ly \[Em]host;
+  \[G]Praise Fa\[Em]ther, \[D]Son, \[Am]and \[G/B G/C]Ho\[D]ly \[G]Ghost.
+  \[C]A\[G]men.
+  \endverse
+  \endsong
+\end{songs}
+
+
+\beginsong{Doxology} [
+  by={Louis Bourgeois and Thomas Ken},
+  sr={Revelation 5:13},
+  cr={Public domain.}
+]
+\beginverse
+\[G]Praise God, \[D]from \[Em]Whom \[Bm]all \[Em]bless\[D]ings \[G]flow;
+\[G]Praise Him, all \[D]crea\[Em]tures \[C]here \[G]be\[D]low;
+\[Em]Praise \[D]Him \[G]a\[D]bove, \[G]ye \[C]heav’n\[D]ly \[Em]host;
+\[G]Praise Fa\[Em]ther, \[D]Son, \[Am]and \[G/B G/C]Ho\[D]ly \[G]Ghost.
+\[C]A\[G]men.
+\endverse \endsong
+
+
+\beginsong{Doxology}
+\beginverse
+\[G]Praise God, \[D]from \[Em]Whom \[Bm]all \[Em]bless\[D]ings \[G]flow;
+\[G]Praise Him, all \[D]crea\[Em]tures \[C]here \[G]be\[D]low;
+\[Em]Praise \[D]Him \[G]a\[D]bove, \[G]ye \[C]heav’n\[D]ly \[Em]host;
+\[G]Praise Fa\[Em]ther, \[D]Son, \[Am]and \[G/B G/C]Ho\[D]ly \[G]Ghost.
+\[C]A\[G]men.
+\endverse \endsong

--- a/test/colorize-results/songs_tex.json
+++ b/test/colorize-results/songs_tex.json
@@ -1,0 +1,986 @@
+[
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.songs.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.latex meta.function.environment.songs.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex meta.function.environment.songs.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "songs",
+		"t": "text.tex.latex meta.function.environment.songs.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex meta.function.environment.songs.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex meta.function.environment.songs.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex meta.function.environment.songs.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "beginsong",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Doxology",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex"
+	},
+	{
+		"c": "by={Louis Bourgeois and Thomas Ken},",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.optional.latex"
+	},
+	{
+		"c": "  sr={Revelation 5:13},",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.optional.latex"
+	},
+	{
+		"c": "  cr={Public domain.}",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.optional.latex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "beginverse",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise God, ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "from ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Whom ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Bm]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "all ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "bless",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ings ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "flow;",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise Him, all ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "crea",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "tures ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "here ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "be",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "low;",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Him ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "a",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "bove, ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ye ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "heav’n",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ly ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "host;",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise Fa",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ther, ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Son, ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Am]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "and ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G/B G/C]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Ho",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ly ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Ghost.",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "A",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "men.",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "endverse",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "endsong",
+		"t": "text.tex.latex meta.function.environment.songs.latex meta.data.environment.songs.latex meta.function.environment.song.latex support.function.be.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.songs.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.latex meta.function.environment.songs.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex meta.function.environment.songs.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "songs",
+		"t": "text.tex.latex meta.function.environment.songs.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex meta.function.environment.songs.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "beginsong",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Doxology",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": " [",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.begin.latex"
+	},
+	{
+		"c": "  by={Louis Bourgeois and Thomas Ken},",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.optional.latex"
+	},
+	{
+		"c": "  sr={Revelation 5:13},",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.optional.latex"
+	},
+	{
+		"c": "  cr={Public domain.}",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.optional.latex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.optional.latex punctuation.definition.arguments.optional.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "beginverse",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise God, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "from ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Whom ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Bm]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "all ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "bless",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ings ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "flow;",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise Him, all ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "crea",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "tures ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "here ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "be",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "low;",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Him ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "a",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "bove, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ye ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "heav’n",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ly ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "host;",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise Fa",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ther, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Son, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Am]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "and ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G/B G/C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Ho",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ly ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Ghost.",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "A",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "men.",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "endverse",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex meta.function.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "endsong",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "beginsong",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Doxology",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.parameter.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "beginverse",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise God, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "from ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Whom ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Bm]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "all ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "bless",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ings ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "flow;",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise Him, all ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "crea",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "tures ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "here ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "be",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "low;",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Him ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "a",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "bove, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ye ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "heav’n",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ly ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "host;",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Praise Fa",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Em]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ther, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Son, ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[Am]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "and ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G/B G/C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Ho",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[D]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "ly ",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "Ghost.",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[C]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "A",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\[G]",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex meta.chord.block.latex support.class.chord.block.environment.latex"
+	},
+	{
+		"c": "men.",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "endverse",
+		"t": "text.tex.latex meta.function.environment.song.latex meta.data.environment.song.latex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex meta.function.environment.song.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "endsong",
+		"t": "text.tex.latex meta.function.environment.song.latex support.function.be.latex"
+	}
+]


### PR DESCRIPTION
Applies `songs environment` highlighting for chord blocks between \beginsong and \endsong
- Resolves #104
- Works correctly and doesn't disrupt `\begin{songs}` (as it it the same meta.evironment tokening)
- It is basically a copy of `\begin{songs}` above, but separated, because was harder to combine the two together.

Preview:
- after: 
  ![LaTeX song after fix](https://github.com/user-attachments/assets/64323de3-947c-4ff8-9227-163a0aede147)
- before:
  ![LaTeX song before](https://github.com/user-attachments/assets/da492e09-765c-4a4a-aeff-800179baed38)
