### PR TITLE
Make "...." a verb construction in doctex

### DIFF
--- a/src/DocTeX.tmLanguage.yaml
+++ b/src/DocTeX.tmLanguage.yaml
@@ -1,13 +1,22 @@
 name: DocTeX
 patterns:
-- captures:
+- match: (?!\\)(\|)([^\|]*)(\|)
+  captures:
     '1':
       name: punctuation.definition.verb.latex
     '2':
       name: markup.raw.verb.latex
     '3':
       name: punctuation.definition.verb.latex
-  match: (\|)([^\|]*)(\|)
+  name: meta.function.verb.latex
+- match: (?!\\)(")([^"]*)(")
+  captures:
+    '1':
+      name: punctuation.definition.verb.latex
+    '2':
+      name: markup.raw.verb.latex
+    '3':
+      name: punctuation.definition.verb.latex
   name: meta.function.verb.latex
 - begin: ^(%)    (\\begin\{macrocode\})
   captures:

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -2,6 +2,7 @@
     "name": "DocTeX",
     "patterns": [
         {
+            "match": "(?!\\\\)(\\|)([^\\|]*)(\\|)",
             "captures": {
                 "1": {
                     "name": "punctuation.definition.verb.latex"
@@ -13,7 +14,21 @@
                     "name": "punctuation.definition.verb.latex"
                 }
             },
-            "match": "(\\|)([^\\|]*)(\\|)",
+            "name": "meta.function.verb.latex"
+        },
+        {
+            "match": "(?!\\\\)(\")([^\"]*)(\")",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.verb.latex"
+                },
+                "2": {
+                    "name": "markup.raw.verb.latex"
+                },
+                "3": {
+                    "name": "punctuation.definition.verb.latex"
+                }
+            },
             "name": "meta.function.verb.latex"
         },
         {

--- a/test/colorization.test.js
+++ b/test/colorization.test.js
@@ -30,8 +30,8 @@ function assertUnchangedTokens(testFixurePath, done) {
                     assert.deepEqual(data, previousData)
                 } catch (e) {
                     // fs.writeFileSync(resultPath, JSON.stringify(data, null, '\t'), { flag: 'w' })
-                    if (Array.isArray(data) && Array.isArray(previousData) && data.length === previousData.length) {
-                        for (let i = 0; i < data.length; i++) {
+                    if (Array.isArray(data) && Array.isArray(previousData)) {
+                        for (let i = 0; i < Math.min(data.length, previousData.length); i++) {
                             let d = data[i]
                             let p = previousData[i]
                             if (d.c !== p.c || p.t !== d.t) {

--- a/test/colorization.test.js
+++ b/test/colorization.test.js
@@ -68,7 +68,7 @@ function hasThemeChange(d, p) {
 suite('colorization', () => {
     let extensionColorizeFixturePath = join(__dirname, 'colorize-fixtures')
     if (fs.existsSync(extensionColorizeFixturePath)) {
-        let fixturesFiles = fs.readdirSync(extensionColorizeFixturePath).filter(f => f.endsWith('.tex') || f.endsWith('.bib') || f.endsWith('.md'))
+        let fixturesFiles = fs.readdirSync(extensionColorizeFixturePath).filter(f => f.endsWith('.tex') || f.endsWith('.bib') || f.endsWith('.md') || f.endsWith('.dtx'))
         fixturesFiles.forEach(fixturesFile => {
             // define a test for each fixture
             test(fixturesFile, (done) => {

--- a/test/colorize-fixtures/basics.dtx
+++ b/test/colorize-fixtures/basics.dtx
@@ -1,0 +1,46 @@
+% Some text
+% $a+b+c
+% x+y+z$
+% Some text
+
+% In |macrocode|, text with |%| should be considered as comment, while text with |^^A| should not.
+%    \begin{macrocode}
+\def\some@command{
+%    \end{macrocode}
+% Comments:
+%    \begin{macrocode}
+   some macro code ...}
+%    \end{macrocode}
+
+%    \begin{macrocode}
+\newcommand\hello@a{xxx}
+%   \newcommand\hello@b{yyy}
+^^A \newcommand\hello@c{zzz}
+%    \end{macrocode}
+
+
+%    \begin{macrocode}
+\begin{equation}
+abc
+% abc
+^^A abc
+\end{equation}
+%    \end{macrocode}
+
+%    \begin{macrocode}
+{abc
+% abc
+^^A abc
+}
+abc
+% abc
+^^A abc
+%    \end{macrocode}
+
+%    \begin{macrocode}
+$
+abc
+% abc
+^^A abc
+$
+%    \end{macrocode}

--- a/test/colorize-fixtures/skeleton.dtx
+++ b/test/colorize-fixtures/skeleton.dtx
@@ -1,0 +1,125 @@
+% \iffalse meta-comment
+%
+% Copyright (C) 2015-2024 Scott Pakin <scott+dtx@pakin.org>
+% ---------------------------------------------------------
+%
+% This file may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License, either version 1.3
+% of this license or (at your option) any later version.
+% The latest version of this license is in:
+%
+%    http://www.latex-project.org/lppl.txt
+%
+% and version 1.3c or later is part of all distributions of LaTeX
+% version 2008-05-04 or later.
+%
+% \fi
+%
+% \iffalse
+%<*driver>
+\ProvidesFile{skeleton.dtx}
+%</driver>
+%<package>\NeedsTeXFormat{LaTeX2e}[2023-11-01]
+%<package>\ProvidesPackage{skeleton}
+%<*package>
+    [2024/01/21 v1.1 .dtx skeleton file]
+%</package>
+%
+%<*driver>
+\documentclass{ltxdoc}
+\usepackage{skeleton}[2004/11/05]
+\EnableCrossrefs
+\CodelineIndex
+\RecordChanges
+\begin{document}
+  \DocInput{skeleton.dtx}
+  \PrintChanges
+  \PrintIndex
+\end{document}
+%</driver>
+% \fi
+%
+% Make "|" and |"| be \enquote{short verb} characters, but not in the
+% document preamble, where an active character may interfere with
+% packages that are loaded.  Remove these short-hands at the end of the
+% document before reading the \file{.aux} file, as they may appear in
+% labels (for instance, \pkg{l3fp} documents an operation "||").
+%    \begin{macrocode}
+\AtBeginDocument
+  {
+    \MakeShortVerb \"
+    \MakeShortVerb \|
+  }
+\AtEndDocument
+  {
+    \DeleteShortVerb \"
+    \DeleteShortVerb \|
+  }
+%    \end{macrocode}
+% \changes{v1.0}{2004/11/05}{Initial version}
+%
+% \GetFileInfo{skeleton.dtx}
+%
+% \DoNotIndex{\newcommand,\newenvironment}
+%
+%
+% \title{The \textsf{skeleton} package\thanks{This document
+%   corresponds to \textsf{skeleton}~\fileversion, dated \filedate.}}
+% \author{Scott Pakin \\ \texttt{scott+dtx@pakin.org}}
+%
+% \maketitle
+%
+% \section{Introduction}
+%
+% Put text here.
+%
+% \section{Usage}
+%
+% Put text here.
+%
+% \DescribeMacro{\dummyMacro}
+% This macro does nothing.\index{doing nothing|usage} It is merely an
+% example.  If this were a real macro, you would put a paragraph here
+% describing what the macro is supposed to do, what its mandatory and
+% optional arguments are, and so forth.
+%
+% \DescribeEnv{dummyEnv}
+% This environment does nothing.  It is merely an example.
+% If this were a real environment, you would put a paragraph here
+% describing what the environment is supposed to do, what its
+% mandatory and optional arguments are, and so forth.
+%
+% \MaybeStop{}
+%
+% \section{Implementation}
+%
+% \begin{macro}{\dummyMacro}
+% This is a dummy macro.  If it did anything, we'd describe its
+% implementation here.
+%    \begin{macrocode}
+\newcommand{\dummyMacro}{}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{environment}{dummyEnv}
+% This is a dummy environment.  If it did anything, we'd describe its
+% implementation here.
+%    \begin{macrocode}
+\newenvironment{dummyEnv}{%
+}{%
+%    \end{macrocode}
+% \changes{v1.0a}{2004/11/05}{Added a spurious change log entry to
+%   show what a change \emph{within} an environment definition looks
+%   like.}
+% Don't use |%| to introduce a code comment within a |macrocode|
+% environment.  Instead, you should typeset all of your comments with
+% \LaTeX---doing so gives much prettier results.  For comments within a
+% macro/environment body, just do an |\end{macrocode}|, include some
+% commentary, and do another |\begin{macrocode}|.  It's that simple.
+%    \begin{macrocode}
+}
+%    \end{macrocode}
+% \end{environment}
+%
+% \Finale
+\endinput

--- a/test/colorize-fixtures/subeqn.dtx
+++ b/test/colorize-fixtures/subeqn.dtx
@@ -1,0 +1,275 @@
+% \iffalse meta-comment
+%
+% Copyright 1999-2024 Johannes L. Braams.  All rights reserved.
+%
+% This file is part of the subeqn package.
+% ----------------------------------------
+%
+% It may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License, either version 1.3c
+% of this license or (at your option) any later version.
+% The latest version of this license is in
+%   http://www.latex-project.org/lppl.txt
+% and version 1.3c or later is part of all distributions of LaTeX
+% version 2008 or later.
+%
+% This work has the LPPL maintenance status "maintained".
+%
+% The Current Maintainer of this work is Johannes Braams.
+%
+% The list of all files belonging to the supertabular package is
+% given in the file `MANIFEST.
+%
+% The list of derived (unpacked) files belonging to the distribution
+% and covered by LPPL is defined by the unpacking scripts (with
+% extension .ins) which are part of the distribution.
+% \fi
+%
+% \CheckSum{84}
+% \iffalse
+% Copyright (C) 1999-2024
+%     Donald Arsenau at reg.triumf.ca,
+%     Johannes Braams texniek at texniek.nl
+%
+%<*dtx>
+\ProvidesFile{subeqn.dtx}
+%</dtx>
+%<package>\NeedsTeXFormat{LaTeX2e}[1998/06/01]
+%<package>\ProvidesPackage{subeqn}
+%<sample>\ProvidesFile{subeqn-sample.tex}
+%<driver>\ProvidesFile{subeqn.drv}
+%\ProvidesFile{subeqn.dtx}
+              [2024/07/21 v2.0c subnumbering of equations]
+%<*driver>
+\documentclass{ltxdoc}
+\begin{document}
+\pagestyle{myheadings}
+\providecommand{\Lenv}[1]{\textsf{#1}}
+\providecommand{\Lopt}[1]{\textsf{#1}}
+\providecommand{\pkg}[1]{\texttt{#1}}
+\providecommand{\file}[1]{\texttt{#1}}
+\DocInput{subeqn.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+%  \GetFileInfo{subeqn.dtx}
+%  \title{Subnumbering of equations\thanks{This file
+%        has version number \fileversion, last
+%        revised \filedate.}}
+%  \author{Donald Arsenau \and Johannes Braams}
+%  \date{\filedate}
+%  \maketitle
+%
+% \markboth
+%      {subeqn package version \fileversion\space as of \filedate}
+%      {subeqn package version \fileversion\space as of \filedate}
+%
+%  \section{Introduction}
+%
+%    Sometimes it is necessary to be able to refer to subexpressions
+%    of an equation. In order to do that these subexpressions should
+%    be numbered. In standard \LaTeX\ there is no provision for
+%    this. To solve this problem Stephen Gildea once wrote
+%    \file{subeqn.sty} for \LaTeX$\:$2.09; Donald Arsenau rewrote the
+%    macros and Johannes Braams made them available for \LaTeXe.
+%
+%    Note that this package is \emph{not} compatible with the package
+%    \pkg{subeqnarray}, written by Johannes Braams.
+%
+%    This package can be used together with the \LaTeX\ options
+%    \Lopt{leqno} and \Lopt{fleqn}.
+%
+%  \section{Available environments}
+%
+% \DescribeEnv{subeqations} Inside the \Lenv{subeqations} environment
+%    \LaTeX's equation environments such as \Lenv{equation} and
+%    \Lenv{eqnarray} are numbered as subexpressions. At the same time
+%    the number of the (main) equation is kept the same.
+%
+% \DescribeEnv{subeqnarray} |\begin{subeqnarray}| works like
+%    |\begin{subequations}||\begin{eqnarray}|, but saves typing.  A
+%    |\label| command given at the very beginning of the first entry
+%    defines a |label| for the overall equation number, as if you had
+%    typed |\begin{subequations}||\label{xxx}||\begin{eqnarray}|.
+%
+%  \section{Available commands}
+%
+% \DescribeMacro{\thesubequation} The command |\thesubequation|
+%    controls the labelling of the subexpressions of an equation. You
+%    can change the labelling by redefining this command, but the
+%    names of the counters may be confusing: The sub-number is given
+%    by counter \texttt{equation}, while the overall equation number
+%    is given by \texttt{mainequation}.
+%
+%    There are two ways to reference the overall equation number:
+%    through its value, as in |\Roman{mainequation}|, or through
+%    |\themainequation|, which gives the text of the normal
+%    |\theequation|. Refer to the local sub-number through the value
+%    of the \texttt{equation} counter, as in |\alph{equation}|.
+%    The default numbering is like 13c, given by:
+%\begin{verbatim}
+%\newcommand*{\thesubequation}{\themainequation\alph{equation}}
+%\end{verbatim}
+%
+%    Some alternatives:\\
+%    A number such as 13.C is achieved by
+%\begin{verbatim}
+%    \newcommand*{\thesubequation}{\themainequation.\Alph{equation}}
+%\end{verbatim}
+%    A number such as 13-iii is achieved by
+%\begin{verbatim}
+%    \newcommand*{\thesubequation}{\themainequation-\roman{equation}}
+%    \newcommand*{\thesubequation}{\themainequation.\Alph{equation}}
+%\end{verbatim}
+%    When the document class which is used has declared  
+%\begin{verbatim}
+%    \renewcommand{\@eqnnum}{\theequation} 
+%    \renewcommand{\theequation}{(\arabic{equation})}
+%\end{verbatim}
+% which puts parentheses around \emph{all} equation numbers, including
+% those produced by the |\ref| command, you can use:
+%\begin{verbatim}
+%\newcommand*{\thesubequation}{(\arabic{mainequation}\alph{equation})}
+%\end{verbatim}
+%
+%  \StopEventually{}
+%
+%  \section{The implementation}
+%
+%    \begin{macrocode}
+%<*package>
+%    \end{macrocode}
+%
+%  \begin{environment}{subeqations}
+%    Within the \Lenv{subequations} the equation numbers consist of
+%    two parts. The first part is a representation of the current value
+%    of the \texttt{equation} counter when the environment is entered,
+%    ie the number of the equation; the second part indicates the
+%    number of the subexpression of the equation.
+%    \begin{macrocode}
+\newenvironment{subequations}{%
+%    \end{macrocode}
+%    First we update the \texttt{equation} counter,
+%    \begin{macrocode}
+  \refstepcounter{equation}%
+%    \end{macrocode}
+%    then we save its current value in |\c@mainequation| and define
+%    |\themainequation| to be the current representation of the
+%    \texttt{equation} counter.
+%    \begin{macrocode}
+  \mathchardef\c@mainequation\c@equation
+  \protected@edef\themainequation{\theequation}%
+%    \end{macrocode}
+%    Then we change the representation of the \texttt{equation}
+%    counter to represent the subexpression number. Finally we set the
+%    \texttt{equation} counter to zero as we use it for counting the
+%    subexpressions. 
+%    \begin{macrocode}
+  \let\theequation\thesubequation
+  \global\c@equation\z@
+  }{%
+%    \end{macrocode}
+%    When the environment is finished we restore the value of the
+%    \texttt{equation} counter.
+%    \begin{macrocode}
+  \global\c@equation\c@mainequation
+  \global\@ignoretrue
+  }
+%    \end{macrocode}
+%  \end{environment}
+%
+%  \begin{macro}{\thesubequation}
+%    By default the subexpressions will be numbered with lower case
+%    letters. The representation of the \texttt{equation} counter also
+%    includes the saved value of the \texttt{equation} counter. This
+%    can be changed by redefining this command.
+%    \begin{macrocode}
+\newcommand{\thesubequation}{\themainequation\alph{equation}}
+%    \end{macrocode}
+%  \end{macro}
+%
+%  \begin{environment}{subeqnarray}
+%    
+%    \begin{macrocode}
+\newenvironment{subeqnarray}{%
+  \subequations
+  \@ifnextchar\label{\@lab@subeqnarray}{\eqnarray}
+  }{%
+  \endeqnarray\endsubequations
+  }
+%    \end{macrocode}
+%  \end{environment}
+%
+%  \begin{macro}{\@lab@subeqnarray}
+%    This macro picks up the |\label| command and its argument and
+%    re-inserts it \emph{before} starting the \Lenv{eqnarray}
+%    environment. 
+%    \begin{macrocode}
+\newcommand*{\@lab@subeqnarray}[2]{#1{#2}\eqnarray}
+%    \end{macrocode}
+%  \end{macro}
+%
+%    \begin{macrocode}
+%</package>
+%    \end{macrocode}
+%
+% \section{An example of the use of this package}
+%
+%    When you run the following document through \LaTeX\ you will see
+%    the differene between the \texttt{subeqnarray} and
+%    \texttt{eqnarray} environments.
+%    \begin{macrocode}
+%<*sample>
+\documentclass{article}
+\usepackage{subeqn}
+
+\begin{document}
+\title{Sample sub-equations}
+\author{Johannes L. Braams}
+\date{\today}
+\maketitle
+
+\noindent
+This is an example of the use of the \texttt{subeqations}
+package. First we have a normal \textsf{equation} environment.
+\begin{equation}
+  \label{a}
+  a^2 + b^2 = c^2
+\end{equation}
+Now we start sub-numbering.
+\begin{subequations}
+  \label{b}
+  \begin{equation}
+    \label{b1}
+    d^2 + e^2 = f^2
+  \end{equation}
+  We can refer to equation~\ref{a}, \ref{b} and~\ref{b1}.
+  \begin{equation}
+    \label{b2}
+    g^2 + h^2 = i^2
+  \end{equation}
+  This was equation~\ref{b2}.
+  \begin{eqnarray}
+    \label{c}
+    x &=& y+z\label{c1}\\
+    u &=& v+w\label{c2}
+  \end{eqnarray}
+  This was expression~\ref{c}, consisting of parts~\ref{c1}
+  and~\ref{c2}. 
+\end{subequations}
+
+\noindent
+Now lets start a \textsf{subeqnarray} environment.
+\begin{subeqnarray}
+  \label{d}
+  x &=& y+z\label{d1}\\
+  u &=& v+w\label{d2}
+\end{subeqnarray}
+This was equation~\ref{d}, with parts~\ref{d1} and~\ref{d2}.  
+\end{document}
+%</sample>
+%    \end{macrocode}
+%
+% \Finale
+\endinput

--- a/test/colorize-results/basics_dtx.json
+++ b/test/colorize-results/basics_dtx.json
@@ -1,0 +1,478 @@
+[
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Some text",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "$",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.definition.string.begin.tex"
+	},
+	{
+		"c": "a",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.math.operator.tex"
+	},
+	{
+		"c": "b",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.math.operator.tex"
+	},
+	{
+		"c": "c",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex comment.line.percentage.doctex"
+	},
+	{
+		"c": " x",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.math.operator.tex"
+	},
+	{
+		"c": "y",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.math.operator.tex"
+	},
+	{
+		"c": "z",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "$",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.definition.string.end.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Some text",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " In ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "macrocode",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ", text with ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " should be considered as comment, while text with ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "^^A",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " should not.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "def",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "some@command",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Comments:",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "   some macro code ...}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newcommand",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "hello@a",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{xxx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "   \\newcommand\\hello@b{yyy}",
+		"t": "text.tex.doctex comment.line.percentage.tex"
+	},
+	{
+		"c": "^^A ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newcommand",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "hello@c",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{zzz}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "abc",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " abc",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex comment.line.percentage.tex"
+	},
+	{
+		"c": "^^A abc",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "{abc",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " abc",
+		"t": "text.tex.doctex comment.line.percentage.tex"
+	},
+	{
+		"c": "^^A abc",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "abc",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " abc",
+		"t": "text.tex.doctex comment.line.percentage.tex"
+	},
+	{
+		"c": "^^A abc",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "$",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.definition.string.begin.tex"
+	},
+	{
+		"c": "abc",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": " abc",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex comment.line.percentage.tex"
+	},
+	{
+		"c": "^^A abc",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex"
+	},
+	{
+		"c": "$",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.definition.string.end.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	}
+]

--- a/test/colorize-results/skeleton_dtx.json
+++ b/test/colorize-results/skeleton_dtx.json
@@ -1,0 +1,1718 @@
+[
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": " meta-comment",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Copyright (C) 2015-2024 Scott Pakin <scott+dtx@pakin.org>",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ---------------------------------------------------------",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " This file may be distributed and/or modified under the",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " conditions of the LaTeX Project Public License, either version 1.3",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " of this license or (at your option) any later version.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " The latest version of this license is in:",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    http://www.latex-project.org/lppl.txt",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " and version 1.3c or later is part of all distributions of LaTeX",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " version 2008-05-04 or later.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": "%<*driver>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ProvidesFile",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{skeleton.dtx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%</driver>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%<package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "NeedsTeXFormat",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{LaTeX2e}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "2023-11-01",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "%<package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ProvidesPackage",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{skeleton}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%<*package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "2024/01/21 v1.1 .dtx skeleton file",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "%</package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%<*driver>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "documentclass",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "ltxdoc",
+		"t": "text.tex.doctex meta.preamble.latex support.class.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "usepackage",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "skeleton",
+		"t": "text.tex.doctex meta.preamble.latex support.class.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "2004/11/05",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "EnableCrossrefs",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "CodelineIndex",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "RecordChanges",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.begin-document.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.begin-document.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.begin-document.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "document",
+		"t": "text.tex.doctex meta.function.begin-document.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.begin-document.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DocInput",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{skeleton.dtx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "PrintChanges",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "PrintIndex",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.end-document.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.end-document.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.end-document.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "document",
+		"t": "text.tex.doctex meta.function.end-document.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.end-document.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%</driver>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Make \"",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\" and ",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\"| be ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "enquote",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{short verb} characters, but not in the",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " document preamble, where an active character may interfere with",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " packages that are loaded.  Remove these short-hands at the end of the",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " document before reading the ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "file",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{.aux} file, as they may appear in",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " labels (for instance, ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "pkg",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{l3fp} documents an operation \"",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "||",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\").",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "AtBeginDocument",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "  {",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "MakeShortVerb",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.doctex constant.character.escape.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "MakeShortVerb",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex constant.character.escape.tex"
+	},
+	{
+		"c": "  }",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "AtEndDocument",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "  {",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DeleteShortVerb",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.doctex constant.character.escape.tex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DeleteShortVerb",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex constant.character.escape.tex"
+	},
+	{
+		"c": "  }",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "changes",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{v1.0}{2004/11/05}{Initial version}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "GetFileInfo",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{skeleton.dtx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DoNotIndex",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newcommand",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": ",",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newenvironment",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "title",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{The ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "textsf",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{skeleton} package",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "thanks",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{This document",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "   corresponds to ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "textsf",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{skeleton}~",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "fileversion",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": ", dated ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "filedate",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": ".}}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "author",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{Scott Pakin ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\\\",
+		"t": "text.tex.doctex keyword.control.newline.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "scott+dtx@pakin.org",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "maketitle",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Introduction",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Put text here.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Usage",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Put text here.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DescribeMacro",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "dummyMacro",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " This macro does nothing.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "index",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{doing nothing|usage} It is merely an",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " example.  If this were a real macro, you would put a paragraph here",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " describing what the macro is supposed to do, what its mandatory and",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " optional arguments are, and so forth.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DescribeEnv",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{dummyEnv}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " This environment does nothing.  It is merely an example.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " If this were a real environment, you would put a paragraph here",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " describing what the environment is supposed to do, what its",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " mandatory and optional arguments are, and so forth.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "MaybeStop",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Implementation",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "macro",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "dummyMacro",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " This is a dummy macro.  If it did anything, we'd describe its",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " implementation here.",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex storage.type.function.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "newcommand",
+		"t": "text.tex.doctex meta.function.environment.general.latex storage.type.function.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.begin.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "dummyMacro",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.end.latex"
+	},
+	{
+		"c": "{}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "macro",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "environment",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{dummyEnv}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " This is a dummy environment.  If it did anything, we'd describe its",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " implementation here.",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newenvironment",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{dummyEnv}{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "}{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "changes",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{v1.0a}{2004/11/05}{Added a spurious change log entry to",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "   show what a change ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex support.function.emph.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "emph",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex support.function.emph.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex punctuation.definition.emph.begin.latex"
+	},
+	{
+		"c": "within",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex markup.italic.emph.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex punctuation.definition.emph.end.latex"
+	},
+	{
+		"c": " an environment definition looks",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "   like.}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Don't use ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " to introduce a code comment within a ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "macrocode",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " environment.  Instead, you should typeset all of your comments with",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "LaTeX",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "---doing so gives much prettier results.  For comments within a",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " macro/environment body, just do an ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ", include some",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " commentary, and do another ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ".  It's that simple.",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "environment",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Finale",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "endinput",
+		"t": "text.tex.doctex support.function.general.tex"
+	}
+]

--- a/test/colorize-results/skeleton_dtx.json
+++ b/test/colorize-results/skeleton_dtx.json
@@ -428,7 +428,23 @@
 		"t": "text.tex.doctex comment.line.percentage.doctex"
 	},
 	{
-		"c": " Make \"",
+		"c": " Make ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " and ",
 		"t": "text.tex.doctex"
 	},
 	{
@@ -436,7 +452,7 @@
 		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
 	},
 	{
-		"c": "\" and ",
+		"c": "\"",
 		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
 	},
 	{
@@ -444,7 +460,7 @@
 		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
 	},
 	{
-		"c": "\"| be ",
+		"c": " be ",
 		"t": "text.tex.doctex"
 	},
 	{
@@ -512,15 +528,23 @@
 		"t": "text.tex.doctex support.function.general.tex"
 	},
 	{
-		"c": "{l3fp} documents an operation \"",
+		"c": "{l3fp} documents an operation ",
 		"t": "text.tex.doctex"
 	},
 	{
-		"c": "||",
+		"c": "\"",
 		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
 	},
 	{
-		"c": "\").",
+		"c": "||",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ").",
 		"t": "text.tex.doctex"
 	},
 	{

--- a/test/colorize-results/subeqn_dtx.json
+++ b/test/colorize-results/subeqn_dtx.json
@@ -120,7 +120,23 @@
 		"t": "text.tex.doctex comment.line.percentage.doctex"
 	},
 	{
-		"c": " This work has the LPPL maintenance status \"maintained\".",
+		"c": " This work has the LPPL maintenance status ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "maintained",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ".",
 		"t": "text.tex.doctex"
 	},
 	{

--- a/test/colorize-results/subeqn_dtx.json
+++ b/test/colorize-results/subeqn_dtx.json
@@ -1,0 +1,5114 @@
+[
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": " meta-comment",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Copyright 1999-2024 Johannes L. Braams.  All rights reserved.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " This file is part of the subeqn package.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ----------------------------------------",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " It may be distributed and/or modified under the",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " conditions of the LaTeX Project Public License, either version 1.3c",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " of this license or (at your option) any later version.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " The latest version of this license is in",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "   http://www.latex-project.org/lppl.txt",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " and version 1.3c or later is part of all distributions of LaTeX",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " version 2008 or later.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " This work has the LPPL maintenance status \"maintained\".",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " The Current Maintainer of this work is Johannes Braams.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " The list of all files belonging to the supertabular package is",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " given in the file `MANIFEST.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " The list of derived (unpacked) files belonging to the distribution",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " and covered by LPPL is defined by the unpacking scripts (with",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " extension .ins) which are part of the distribution.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "CheckSum",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{84}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "iffalse",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " Copyright (C) 1999-2024",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "     Donald Arsenau at reg.triumf.ca,",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "     Johannes Braams texniek at texniek.nl",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%<*dtx>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ProvidesFile",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn.dtx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%</dtx>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%<package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "NeedsTeXFormat",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{LaTeX2e}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "1998/06/01",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "%<package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ProvidesPackage",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%<sample>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ProvidesFile",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn-sample.tex}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%<driver>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ProvidesFile",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn.drv}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "ProvidesFile",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn.dtx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "              ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "2024/07/21 v2.0c subnumbering of equations",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "%<*driver>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "documentclass",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "ltxdoc",
+		"t": "text.tex.doctex meta.preamble.latex support.class.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.begin-document.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.begin-document.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.begin-document.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "document",
+		"t": "text.tex.doctex meta.function.begin-document.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.begin-document.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "pagestyle",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{myheadings}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "providecommand",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lenv",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "1",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "textsf",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{#1}}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "providecommand",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lopt",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "1",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "textsf",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{#1}}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "providecommand",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "pkg",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "1",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "#1",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "providecommand",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "file",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "1",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "#1",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DocInput",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn.dtx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.end-document.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.end-document.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.end-document.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "document",
+		"t": "text.tex.doctex meta.function.end-document.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.end-document.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%</driver>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex keyword.control.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": "fi",
+		"t": "text.tex.doctex keyword.control.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "GetFileInfo",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn.dtx}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "title",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{Subnumbering of equations",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "thanks",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{This file",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "        has version number ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "fileversion",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": ", last",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "        revised ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "filedate",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": ".}}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "author",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{Donald Arsenau ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "and",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.space-after-command.latex"
+	},
+	{
+		"c": "Johannes Braams}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "date",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "filedate",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "maketitle",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "markboth",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "      {subeqn package version ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "fileversion",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "space",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.space-after-command.latex"
+	},
+	{
+		"c": "as of ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "filedate",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "      {subeqn package version ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "fileversion",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "space",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.space-after-command.latex"
+	},
+	{
+		"c": "as of ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "filedate",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Introduction",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    Sometimes it is necessary to be able to refer to subexpressions",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    of an equation. In order to do that these subexpressions should",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    be numbered. In standard ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "LaTeX",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex constant.character.escape.tex"
+	},
+	{
+		"c": "there is no provision for",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    this. To solve this problem Stephen Gildea once wrote",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "file",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqn.sty} for ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "LaTeX",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "$",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.definition.string.begin.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": ":",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex constant.character.escape.tex"
+	},
+	{
+		"c": "$",
+		"t": "text.tex.doctex meta.math.block.tex support.class.math.block.tex punctuation.definition.string.end.tex"
+	},
+	{
+		"c": "2.09; Donald Arsenau rewrote the",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    macros and Johannes Braams made them available for ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "LaTeXe",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    Note that this package is ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.emph.latex support.function.emph.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "emph",
+		"t": "text.tex.doctex meta.function.emph.latex support.function.emph.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.emph.latex punctuation.definition.emph.begin.latex"
+	},
+	{
+		"c": "not",
+		"t": "text.tex.doctex meta.function.emph.latex markup.italic.emph.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.emph.latex punctuation.definition.emph.end.latex"
+	},
+	{
+		"c": " compatible with the package",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "pkg",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqnarray}, written by Johannes Braams.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    This package can be used together with the ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "LaTeX",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex constant.character.escape.tex"
+	},
+	{
+		"c": "options",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lopt",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{leqno} and ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lopt",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{fleqn}.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Available environments",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DescribeEnv",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqations} Inside the ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lenv",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqations} environment",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "LaTeX",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "'s equation environments such as ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lenv",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{equation} and",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lenv",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{eqnarray} are numbered as subexpressions. At the same time",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    the number of the (main) equation is kept the same.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DescribeEnv",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqnarray} ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\begin{subeqnarray}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " works like",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\begin{subequations}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "||",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\begin{eqnarray}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ", but saves typing.  A",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\label",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " command given at the very beginning of the first entry",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    defines a ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " for the overall equation number, as if you had",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    typed ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\begin{subequations}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "||",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\label{xxx}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "||",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\begin{eqnarray}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "Available commands",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "DescribeMacro",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "thesubequation",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "} The command ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\thesubequation",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    controls the labelling of the subexpressions of an equation. You",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    can change the labelling by redefining this command, but the",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    names of the counters may be confusing: The sub-number is given",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    by counter ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": ", while the overall equation number",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    is given by ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "mainequation",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    There are two ways to reference the overall equation number:",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    through its value, as in ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\Roman{mainequation}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ", or through",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\themainequation",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ", which gives the text of the normal",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\theequation",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ". Refer to the local sub-number through the value",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    of the ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter, as in ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\alph{equation}",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    The default numbering is like 13c, given by:",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%\\newcommand*{\\thesubequation}{\\themainequation\\alph{equation}}",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    Some alternatives:",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\\\",
+		"t": "text.tex.doctex keyword.control.newline.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    A number such as 13.C is achieved by",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%    \\newcommand*{\\thesubequation}{\\themainequation.\\Alph{equation}}",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    A number such as 13-iii is achieved by",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%    \\newcommand*{\\thesubequation}{\\themainequation-\\roman{equation}}",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "%    \\newcommand*{\\thesubequation}{\\themainequation.\\Alph{equation}}",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    When the document class which is used has declared  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%    \\renewcommand{\\@eqnnum}{\\theequation} ",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "%    \\renewcommand{\\theequation}{(\\arabic{equation})}",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " which puts parentheses around ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.emph.latex support.function.emph.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "emph",
+		"t": "text.tex.doctex meta.function.emph.latex support.function.emph.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.emph.latex punctuation.definition.emph.begin.latex"
+	},
+	{
+		"c": "all",
+		"t": "text.tex.doctex meta.function.emph.latex markup.italic.emph.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.emph.latex punctuation.definition.emph.end.latex"
+	},
+	{
+		"c": " equation numbers, including",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " those produced by the ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\ref",
+		"t": "text.tex.doctex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " command, you can use:",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%\\newcommand*{\\thesubequation}{(\\arabic{mainequation}\\alph{equation})}",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.verbatim.latex markup.raw.verbatim.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.verbatim.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "verbatim",
+		"t": "text.tex.doctex meta.function.verbatim.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.verbatim.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "StopEventually",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "The implementation",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%<*package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "environment",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{subeqations}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    Within the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lenv",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{subequations} the equation numbers consist of",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    two parts. The first part is a representation of the current value",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    of the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter when the environment is entered,",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ie the number of the equation; the second part indicates the",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    number of the subexpression of the equation.",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newenvironment",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{subequations}{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    First we update the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter,",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "refstepcounter",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{equation}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    then we save its current value in ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\c@mainequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " and define",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\themainequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " to be the current representation of the",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter.",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "mathchardef",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "c@mainequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "c@equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "protected@edef",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "themainequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "theequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    Then we change the representation of the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    counter to represent the subexpression number. Finally we set the",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter to zero as we use it for counting the",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    subexpressions. ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "let",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "theequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "thesubequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "global",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "c@equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "z@",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "  }{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    When the environment is finished we restore the value of the",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter.",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "global",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "c@equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "c@mainequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "global",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@ignoretrue",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "  }",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "environment",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "macro",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "thesubequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    By default the subexpressions will be numbered with lower case",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    letters. The representation of the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter also",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    includes the saved value of the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " counter. This",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    can be changed by redefining this command.",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex storage.type.function.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "newcommand",
+		"t": "text.tex.doctex meta.function.environment.general.latex storage.type.function.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.begin.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "thesubequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.end.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "themainequation",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "alph",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{equation}}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "macro",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "environment",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{subeqnarray}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "newenvironment",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{subeqnarray}{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "subequations",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@ifnextchar",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "\\@",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex"
+	},
+	{
+		"c": "lab",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "@",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex"
+	},
+	{
+		"c": "subeqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "eqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "  }{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.tex punctuation.definition.comment.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "endeqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "endsubequations",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "  }",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "environment",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "macro",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "@lab@subeqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    This macro picks up the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": "\\label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex markup.raw.verb.latex"
+	},
+	{
+		"c": "|",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.verb.latex punctuation.definition.verb.latex"
+	},
+	{
+		"c": " command and its argument and",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    re-inserts it ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex support.function.emph.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "emph",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex support.function.emph.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex punctuation.definition.emph.begin.latex"
+	},
+	{
+		"c": "before",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex markup.italic.emph.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.emph.latex punctuation.definition.emph.end.latex"
+	},
+	{
+		"c": " starting the ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Lenv",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "{eqnarray}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    environment. ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex storage.type.function.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "newcommand",
+		"t": "text.tex.doctex meta.function.environment.general.latex storage.type.function.latex"
+	},
+	{
+		"c": "*",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.begin.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "@lab@subeqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.end.latex"
+	},
+	{
+		"c": "[",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "]",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.brackets.tex"
+	},
+	{
+		"c": "{#1{#2}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "eqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex meta.function.environment.general.latex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex meta.function.environment.general.latex comment.line.percentage.doctex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "macro",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%</package>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "section",
+		"t": "text.tex.doctex meta.function.section.section.latex support.function.section.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "An example of the use of this package",
+		"t": "text.tex.doctex meta.function.section.section.latex entity.name.section.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.section.section.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    When you run the following document through ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "LaTeX",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex constant.character.escape.tex punctuation.definition.keyword.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex constant.character.escape.tex"
+	},
+	{
+		"c": "you will see",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    the differene between the ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "subeqnarray",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " and",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "eqnarray",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": " environments.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\begin{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%<*sample>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "documentclass",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "article",
+		"t": "text.tex.doctex meta.preamble.latex support.class.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "usepackage",
+		"t": "text.tex.doctex meta.preamble.latex keyword.control.preamble.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "subeqn",
+		"t": "text.tex.doctex meta.preamble.latex support.class.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.preamble.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.begin-document.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.begin-document.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.begin-document.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "document",
+		"t": "text.tex.doctex meta.function.begin-document.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.begin-document.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "title",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{Sample sub-equations}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "author",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{Johannes L. Braams}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "date",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "today",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "maketitle",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "noindent",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "This is an example of the use of the ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "texttt",
+		"t": "text.tex.doctex meta.function.texttt.latex support.function.texttt.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.begin.latex"
+	},
+	{
+		"c": "subeqations",
+		"t": "text.tex.doctex meta.function.texttt.latex markup.raw.texttt.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.texttt.latex punctuation.definition.texttt.end.latex"
+	},
+	{
+		"c": "package. First we have a normal ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "textsf",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{equation} environment.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "a",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  a",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": " b",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": " = c",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "Now we start sub-numbering.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "subequations",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "b",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "b1",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "    d",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": " e",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": " = f",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  We can refer to equation~",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "a",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": ", ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "b",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": " and~",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "b1",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "b2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "    g",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": " h",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": " = i",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "^",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex constant.numeric.math.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "equation",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  This was equation~",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "b2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "eqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "c",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "    x ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "&",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex keyword.control.equation.align.latex"
+	},
+	{
+		"c": "=",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "&",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex keyword.control.equation.align.latex"
+	},
+	{
+		"c": " y",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "z",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "c1",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex keyword.control.equation.newline.latex"
+	},
+	{
+		"c": "    u ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "&",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex keyword.control.equation.align.latex"
+	},
+	{
+		"c": "=",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "&",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex keyword.control.equation.align.latex"
+	},
+	{
+		"c": " v",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "+",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex punctuation.math.operator.tex"
+	},
+	{
+		"c": "w",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "c2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex meta.math.block.latex support.class.math.block.environment.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "eqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.function.environment.math.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  This was expression~",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "c",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": ", consisting of parts~",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "c1",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  and~",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "c2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": ". ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "subequations",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "noindent",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "Now lets start a ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "textsf",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "{subeqnarray} environment.",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "begin",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "subeqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "d",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "  x &=& y+z",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "d1",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex keyword.control.newline.tex"
+	},
+	{
+		"c": "  u &=& v+w",
+		"t": "text.tex.doctex meta.function.environment.general.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "label",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex keyword.control.label.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "d2",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex variable.parameter.definition.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex meta.definition.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.environment.general.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "subeqnarray",
+		"t": "text.tex.doctex meta.function.environment.general.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.environment.general.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "This was equation~",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "d",
+		"t": "text.tex.doctex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": ", with parts~",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "d1",
+		"t": "text.tex.doctex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": " and~",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.reference.label.latex keyword.control.ref.latex punctuation.definition.keyword.latex"
+	},
+	{
+		"c": "ref",
+		"t": "text.tex.doctex meta.reference.label.latex keyword.control.ref.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.reference.label.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "d2",
+		"t": "text.tex.doctex meta.reference.label.latex constant.other.reference.label.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.reference.label.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": ".  ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex meta.function.end-document.latex support.function.be.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.doctex meta.function.end-document.latex support.function.be.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.doctex meta.function.end-document.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "document",
+		"t": "text.tex.doctex meta.function.end-document.latex variable.parameter.function.latex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.doctex meta.function.end-document.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "%</sample>",
+		"t": "text.tex.doctex entity.name.function.filename.latex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\end{macrocode}",
+		"t": "text.tex.doctex entity.name.tag.macrocode.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": "%",
+		"t": "text.tex.doctex comment.line.percentage.doctex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.doctex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "Finale",
+		"t": "text.tex.doctex support.function.general.tex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.doctex support.function.general.tex punctuation.definition.function.tex"
+	},
+	{
+		"c": "endinput",
+		"t": "text.tex.doctex support.function.general.tex"
+	}
+]


### PR DESCRIPTION
https://github.com/James-Yu/LaTeX-Workshop/issues/4547

In `.dtx` files, the syntax `"..."` is often used as a short verbatim in a similar way to `|...|`. I believe that it is less harmful to consider the content of "...." as verbatim when it should not be than to not consider it as verbatim when it is.