### PR TITLE
Refactor Bibtex

### DIFF
--- a/src/Bibtex.tmLanguage.yaml
+++ b/src/Bibtex.tmLanguage.yaml
@@ -1,133 +1,140 @@
-comment: 'Grammar based on description from https://github.com/aclements/biblib
-
-  '
+comment: 'Grammar based on description from https://github.com/aclements/biblib'
 name: BibTeX
 patterns:
-- captures:
+- match: '@(?i:comment)(?=[\s{(])'
+  captures:
     '0':
       name: punctuation.definition.comment.bibtex
-  match: '@(?i:comment)(?=[\s{(])'
   name: comment.block.at-sign.bibtex
-- begin: ((@)(?i:preamble))\s*(\{)\s*
-  beginCaptures:
-    '1':
-      name: keyword.other.preamble.bibtex
-    '2':
-      name: punctuation.definition.keyword.bibtex
-    '3':
-      name: punctuation.section.preamble.begin.bibtex
-  end: \}
-  endCaptures:
-    '0':
-      name: punctuation.section.preamble.end.bibtex
-  name: meta.preamble.braces.bibtex
-  patterns:
-  - include: '#field_value'
-- begin: ((@)(?i:preamble))\s*(\()\s*
-  beginCaptures:
-    '1':
-      name: keyword.other.preamble.bibtex
-    '2':
-      name: punctuation.definition.keyword.bibtex
-    '3':
-      name: punctuation.section.preamble.begin.bibtex
-  end: \)
-  endCaptures:
-    '0':
-      name: punctuation.section.preamble.end.bibtex
-  name: meta.preamble.parenthesis.bibtex
-  patterns:
-  - include: '#field_value'
-- begin: ((@)(?i:string))\s*(\{)\s*([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)
-  beginCaptures:
-    '1':
-      name: keyword.other.string-constant.bibtex
-    '2':
-      name: punctuation.definition.keyword.bibtex
-    '3':
-      name: punctuation.section.string-constant.begin.bibtex
-    '4':
-      name: variable.other.bibtex
-  end: \}
-  endCaptures:
-    '0':
-      name: punctuation.section.string-constant.end.bibtex
-  name: meta.string-constant.braces.bibtex
-  patterns:
-  - include: '#field_value'
-- begin: ((@)(?i:string))\s*(\()\s*([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)
-  beginCaptures:
-    '1':
-      name: keyword.other.string-constant.bibtex
-    '2':
-      name: punctuation.definition.keyword.bibtex
-    '3':
-      name: punctuation.section.string-constant.begin.bibtex
-    '4':
-      name: variable.other.bibtex
-  end: \)
-  endCaptures:
-    '0':
-      name: punctuation.section.string-constant.end.bibtex
-  name: meta.string-constant.parenthesis.bibtex
-  patterns:
-  - include: '#field_value'
-- begin: ((@)[a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\{)\s*([^\s,}]*)
-  beginCaptures:
-    '1':
-      name: keyword.other.entry-type.bibtex
-    '2':
-      name: punctuation.definition.keyword.bibtex
-    '3':
-      name: punctuation.section.entry.begin.bibtex
-    '4':
-      name: entity.name.type.entry-key.bibtex
-  end: \}
-  endCaptures:
-    '0':
-      name: punctuation.section.entry.end.bibtex
-  name: meta.entry.braces.bibtex
-  patterns:
-  - begin: ([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\=)
-    beginCaptures:
-      '1':
-        name: support.function.key.bibtex
-      '2':
-        name: punctuation.separator.key-value.bibtex
-    end: (?=[,}])
-    name: meta.key-assignment.bibtex
-    patterns:
-    - include: '#field_value'
-- begin: ((@)[a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\()\s*([^\s,]*)
-  beginCaptures:
-    '1':
-      name: keyword.other.entry-type.bibtex
-    '2':
-      name: punctuation.definition.keyword.bibtex
-    '3':
-      name: punctuation.section.entry.begin.bibtex
-    '4':
-      name: entity.name.type.entry-key.bibtex
-  end: \)
-  endCaptures:
-    '0':
-      name: punctuation.section.entry.end.bibtex
-  name: meta.entry.parenthesis.bibtex
-  patterns:
-  - begin: ([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\=)
-    beginCaptures:
-      '1':
-        name: support.function.key.bibtex
-      '2':
-        name: punctuation.separator.key-value.bibtex
-    end: (?=[,)])
-    name: meta.key-assignment.bibtex
-    patterns:
-    - include: '#field_value'
+- include: '#preamble'
+- include: '#string'
+- include: '#entry'
 - begin: '[^@\n]'
   end: (?=@)
   name: comment.block.bibtex
 repository:
+  preamble:
+    patterns:
+    - begin: ((@)(?i:preamble))\s*(\{)\s*
+      beginCaptures:
+        '1':
+          name: keyword.other.preamble.bibtex
+        '2':
+          name: punctuation.definition.keyword.bibtex
+        '3':
+          name: punctuation.section.preamble.begin.bibtex
+      end: \}
+      endCaptures:
+        '0':
+          name: punctuation.section.preamble.end.bibtex
+      name: meta.preamble.braces.bibtex
+      patterns:
+      - include: '#field_value'
+    - begin: ((@)(?i:preamble))\s*(\()\s*
+      beginCaptures:
+        '1':
+          name: keyword.other.preamble.bibtex
+        '2':
+          name: punctuation.definition.keyword.bibtex
+        '3':
+          name: punctuation.section.preamble.begin.bibtex
+      end: \)
+      endCaptures:
+        '0':
+          name: punctuation.section.preamble.end.bibtex
+      name: meta.preamble.parenthesis.bibtex
+      patterns:
+      - include: '#field_value'
+  string:
+    patterns:
+    - begin: ((@)(?i:string))\s*(\{)\s*([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)
+      beginCaptures:
+        '1':
+          name: keyword.other.string-constant.bibtex
+        '2':
+          name: punctuation.definition.keyword.bibtex
+        '3':
+          name: punctuation.section.string-constant.begin.bibtex
+        '4':
+          name: variable.other.bibtex
+      end: \}
+      endCaptures:
+        '0':
+          name: punctuation.section.string-constant.end.bibtex
+      name: meta.string-constant.braces.bibtex
+      patterns:
+      - include: '#field_value'
+    - begin: ((@)(?i:string))\s*(\()\s*([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)
+      beginCaptures:
+        '1':
+          name: keyword.other.string-constant.bibtex
+        '2':
+          name: punctuation.definition.keyword.bibtex
+        '3':
+          name: punctuation.section.string-constant.begin.bibtex
+        '4':
+          name: variable.other.bibtex
+      end: \)
+      endCaptures:
+        '0':
+          name: punctuation.section.string-constant.end.bibtex
+      name: meta.string-constant.parenthesis.bibtex
+      patterns:
+      - include: '#field_value'
+  entry:
+    patterns:
+    - begin: ((@)[a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\{)\s*([^\s,}]*)
+      beginCaptures:
+        '1':
+          name: keyword.other.entry-type.bibtex
+        '2':
+          name: punctuation.definition.keyword.bibtex
+        '3':
+          name: punctuation.section.entry.begin.bibtex
+        '4':
+          name: entity.name.type.entry-key.bibtex
+      end: \}
+      endCaptures:
+        '0':
+          name: punctuation.section.entry.end.bibtex
+      name: meta.entry.braces.bibtex
+      patterns:
+      - begin: ([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\=)
+        beginCaptures:
+          '1':
+            name: support.function.key.bibtex
+          '2':
+            name: punctuation.separator.key-value.bibtex
+        end: (?=[,}])
+        name: meta.key-assignment.bibtex
+        patterns:
+        - include: '#field_value'
+    - begin: ((@)[a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\()\s*([^\s,]*)
+      beginCaptures:
+        '1':
+          name: keyword.other.entry-type.bibtex
+        '2':
+          name: punctuation.definition.keyword.bibtex
+        '3':
+          name: punctuation.section.entry.begin.bibtex
+        '4':
+          name: entity.name.type.entry-key.bibtex
+      end: \)
+      endCaptures:
+        '0':
+          name: punctuation.section.entry.end.bibtex
+      name: meta.entry.parenthesis.bibtex
+      patterns:
+      - begin: ([a-zA-Z!$&*+\-./:;<>?@\[\\\]^_`|~][a-zA-Z0-9!$&*+\-./:;<>?@\[\\\]^_`|~]*)\s*(\=)
+        beginCaptures:
+          '1':
+            name: support.function.key.bibtex
+          '2':
+            name: punctuation.separator.key-value.bibtex
+        end: (?=[,)])
+        name: meta.key-assignment.bibtex
+        patterns:
+        - include: '#field_value'
   field_value:
     patterns:
     - include: '#string_content'

--- a/syntaxes/Bibtex.tmLanguage.json
+++ b/syntaxes/Bibtex.tmLanguage.json
@@ -1,213 +1,24 @@
 {
-    "comment": "Grammar based on description from https://github.com/aclements/biblib\n",
+    "comment": "Grammar based on description from https://github.com/aclements/biblib",
     "name": "BibTeX",
     "patterns": [
         {
+            "match": "@(?i:comment)(?=[\\s{(])",
             "captures": {
                 "0": {
                     "name": "punctuation.definition.comment.bibtex"
                 }
             },
-            "match": "@(?i:comment)(?=[\\s{(])",
             "name": "comment.block.at-sign.bibtex"
         },
         {
-            "begin": "((@)(?i:preamble))\\s*(\\{)\\s*",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.preamble.bibtex"
-                },
-                "2": {
-                    "name": "punctuation.definition.keyword.bibtex"
-                },
-                "3": {
-                    "name": "punctuation.section.preamble.begin.bibtex"
-                }
-            },
-            "end": "\\}",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.section.preamble.end.bibtex"
-                }
-            },
-            "name": "meta.preamble.braces.bibtex",
-            "patterns": [
-                {
-                    "include": "#field_value"
-                }
-            ]
+            "include": "#preamble"
         },
         {
-            "begin": "((@)(?i:preamble))\\s*(\\()\\s*",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.preamble.bibtex"
-                },
-                "2": {
-                    "name": "punctuation.definition.keyword.bibtex"
-                },
-                "3": {
-                    "name": "punctuation.section.preamble.begin.bibtex"
-                }
-            },
-            "end": "\\)",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.section.preamble.end.bibtex"
-                }
-            },
-            "name": "meta.preamble.parenthesis.bibtex",
-            "patterns": [
-                {
-                    "include": "#field_value"
-                }
-            ]
+            "include": "#string"
         },
         {
-            "begin": "((@)(?i:string))\\s*(\\{)\\s*([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.string-constant.bibtex"
-                },
-                "2": {
-                    "name": "punctuation.definition.keyword.bibtex"
-                },
-                "3": {
-                    "name": "punctuation.section.string-constant.begin.bibtex"
-                },
-                "4": {
-                    "name": "variable.other.bibtex"
-                }
-            },
-            "end": "\\}",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.section.string-constant.end.bibtex"
-                }
-            },
-            "name": "meta.string-constant.braces.bibtex",
-            "patterns": [
-                {
-                    "include": "#field_value"
-                }
-            ]
-        },
-        {
-            "begin": "((@)(?i:string))\\s*(\\()\\s*([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.string-constant.bibtex"
-                },
-                "2": {
-                    "name": "punctuation.definition.keyword.bibtex"
-                },
-                "3": {
-                    "name": "punctuation.section.string-constant.begin.bibtex"
-                },
-                "4": {
-                    "name": "variable.other.bibtex"
-                }
-            },
-            "end": "\\)",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.section.string-constant.end.bibtex"
-                }
-            },
-            "name": "meta.string-constant.parenthesis.bibtex",
-            "patterns": [
-                {
-                    "include": "#field_value"
-                }
-            ]
-        },
-        {
-            "begin": "((@)[a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\{)\\s*([^\\s,}]*)",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.entry-type.bibtex"
-                },
-                "2": {
-                    "name": "punctuation.definition.keyword.bibtex"
-                },
-                "3": {
-                    "name": "punctuation.section.entry.begin.bibtex"
-                },
-                "4": {
-                    "name": "entity.name.type.entry-key.bibtex"
-                }
-            },
-            "end": "\\}",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.section.entry.end.bibtex"
-                }
-            },
-            "name": "meta.entry.braces.bibtex",
-            "patterns": [
-                {
-                    "begin": "([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\=)",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "support.function.key.bibtex"
-                        },
-                        "2": {
-                            "name": "punctuation.separator.key-value.bibtex"
-                        }
-                    },
-                    "end": "(?=[,}])",
-                    "name": "meta.key-assignment.bibtex",
-                    "patterns": [
-                        {
-                            "include": "#field_value"
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "begin": "((@)[a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\()\\s*([^\\s,]*)",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.entry-type.bibtex"
-                },
-                "2": {
-                    "name": "punctuation.definition.keyword.bibtex"
-                },
-                "3": {
-                    "name": "punctuation.section.entry.begin.bibtex"
-                },
-                "4": {
-                    "name": "entity.name.type.entry-key.bibtex"
-                }
-            },
-            "end": "\\)",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.section.entry.end.bibtex"
-                }
-            },
-            "name": "meta.entry.parenthesis.bibtex",
-            "patterns": [
-                {
-                    "begin": "([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\=)",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "support.function.key.bibtex"
-                        },
-                        "2": {
-                            "name": "punctuation.separator.key-value.bibtex"
-                        }
-                    },
-                    "end": "(?=[,)])",
-                    "name": "meta.key-assignment.bibtex",
-                    "patterns": [
-                        {
-                            "include": "#field_value"
-                        }
-                    ]
-                }
-            ]
+            "include": "#entry"
         },
         {
             "begin": "[^@\\n]",
@@ -216,6 +27,216 @@
         }
     ],
     "repository": {
+        "preamble": {
+            "patterns": [
+                {
+                    "begin": "((@)(?i:preamble))\\s*(\\{)\\s*",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.preamble.bibtex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.keyword.bibtex"
+                        },
+                        "3": {
+                            "name": "punctuation.section.preamble.begin.bibtex"
+                        }
+                    },
+                    "end": "\\}",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.preamble.end.bibtex"
+                        }
+                    },
+                    "name": "meta.preamble.braces.bibtex",
+                    "patterns": [
+                        {
+                            "include": "#field_value"
+                        }
+                    ]
+                },
+                {
+                    "begin": "((@)(?i:preamble))\\s*(\\()\\s*",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.preamble.bibtex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.keyword.bibtex"
+                        },
+                        "3": {
+                            "name": "punctuation.section.preamble.begin.bibtex"
+                        }
+                    },
+                    "end": "\\)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.preamble.end.bibtex"
+                        }
+                    },
+                    "name": "meta.preamble.parenthesis.bibtex",
+                    "patterns": [
+                        {
+                            "include": "#field_value"
+                        }
+                    ]
+                }
+            ]
+        },
+        "string": {
+            "patterns": [
+                {
+                    "begin": "((@)(?i:string))\\s*(\\{)\\s*([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.string-constant.bibtex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.keyword.bibtex"
+                        },
+                        "3": {
+                            "name": "punctuation.section.string-constant.begin.bibtex"
+                        },
+                        "4": {
+                            "name": "variable.other.bibtex"
+                        }
+                    },
+                    "end": "\\}",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.string-constant.end.bibtex"
+                        }
+                    },
+                    "name": "meta.string-constant.braces.bibtex",
+                    "patterns": [
+                        {
+                            "include": "#field_value"
+                        }
+                    ]
+                },
+                {
+                    "begin": "((@)(?i:string))\\s*(\\()\\s*([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.string-constant.bibtex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.keyword.bibtex"
+                        },
+                        "3": {
+                            "name": "punctuation.section.string-constant.begin.bibtex"
+                        },
+                        "4": {
+                            "name": "variable.other.bibtex"
+                        }
+                    },
+                    "end": "\\)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.string-constant.end.bibtex"
+                        }
+                    },
+                    "name": "meta.string-constant.parenthesis.bibtex",
+                    "patterns": [
+                        {
+                            "include": "#field_value"
+                        }
+                    ]
+                }
+            ]
+        },
+        "entry": {
+            "patterns": [
+                {
+                    "begin": "((@)[a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\{)\\s*([^\\s,}]*)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.entry-type.bibtex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.keyword.bibtex"
+                        },
+                        "3": {
+                            "name": "punctuation.section.entry.begin.bibtex"
+                        },
+                        "4": {
+                            "name": "entity.name.type.entry-key.bibtex"
+                        }
+                    },
+                    "end": "\\}",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.entry.end.bibtex"
+                        }
+                    },
+                    "name": "meta.entry.braces.bibtex",
+                    "patterns": [
+                        {
+                            "begin": "([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\=)",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "support.function.key.bibtex"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.bibtex"
+                                }
+                            },
+                            "end": "(?=[,}])",
+                            "name": "meta.key-assignment.bibtex",
+                            "patterns": [
+                                {
+                                    "include": "#field_value"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "begin": "((@)[a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\()\\s*([^\\s,]*)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.entry-type.bibtex"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.keyword.bibtex"
+                        },
+                        "3": {
+                            "name": "punctuation.section.entry.begin.bibtex"
+                        },
+                        "4": {
+                            "name": "entity.name.type.entry-key.bibtex"
+                        }
+                    },
+                    "end": "\\)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.entry.end.bibtex"
+                        }
+                    },
+                    "name": "meta.entry.parenthesis.bibtex",
+                    "patterns": [
+                        {
+                            "begin": "([a-zA-Z!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~][a-zA-Z0-9!$&*+\\-./:;<>?@\\[\\\\\\]^_`|~]*)\\s*(\\=)",
+                            "beginCaptures": {
+                                "1": {
+                                    "name": "support.function.key.bibtex"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.bibtex"
+                                }
+                            },
+                            "end": "(?=[,)])",
+                            "name": "meta.key-assignment.bibtex",
+                            "patterns": [
+                                {
+                                    "include": "#field_value"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
         "field_value": {
             "patterns": [
                 {


### PR DESCRIPTION
Move all rules into the repository section to make the parsing logic clearer. It will hopefully ease maintenance.