### PR TITLE
Match braces inside luaexec

### DIFF
--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -784,6 +784,7 @@ patterns:
   contentName: source.lua
   patterns:
   - include: source.lua
+  - include: text.tex#braces
 - match: \\(?:newline|pagebreak|clearpage|linebreak|pause)(?:\b)
   name: keyword.control.layout.latex
 - begin: \\\(

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -3817,6 +3817,9 @@
                     "patterns": [
                         {
                             "include": "source.lua"
+                        },
+                        {
+                            "include": "text.tex#braces"
                         }
                     ]
                 },

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -3720,6 +3720,9 @@
             "patterns": [
                 {
                     "include": "source.lua"
+                },
+                {
+                    "include": "text.tex#braces"
                 }
             ]
         },

--- a/test/colorize-fixtures/code-lua.tex
+++ b/test/colorize-fixtures/code-lua.tex
@@ -23,3 +23,16 @@
     g:Dlabeldot("$A$", A, {pos="S"})
     g:Show()
 \end{luadraw}
+
+\directlua{
+  local i
+  local t = { }
+  for _,i in pairs(tex.extraprimitives("luatex")) do
+    if string.match(i,"^U") then
+      if not string.match(i,"^Uchar$") then
+        table.insert(t,i)
+      end
+    end
+  end
+  tex.enableprimitives("", t)
+}

--- a/test/colorize-results/code-lua_tex.json
+++ b/test/colorize-results/code-lua_tex.json
@@ -1306,5 +1306,353 @@
 	{
 		"c": "}",
 		"t": "text.tex.latex punctuation.definition.arguments.end.latex"
+	},
+	{
+		"c": "\\",
+		"t": "text.tex.latex support.function.verb.latex punctuation.definition.function.latex"
+	},
+	{
+		"c": "directlua",
+		"t": "text.tex.latex support.function.verb.latex"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex punctuation.definition.arguments.begin.latex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "local",
+		"t": "text.tex.latex source.lua keyword.local.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "i",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "local",
+		"t": "text.tex.latex source.lua keyword.local.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "t",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "=",
+		"t": "text.tex.latex source.lua keyword.operator.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "{",
+		"t": "text.tex.latex source.lua meta.group.braces.tex punctuation.group.begin.tex"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua meta.group.braces.tex"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex source.lua meta.group.braces.tex punctuation.group.end.tex"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "for",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "_",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ",",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "i",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "in",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "pairs",
+		"t": "text.tex.latex source.lua support.function.lua"
+	},
+	{
+		"c": "(",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "tex",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "extraprimitives",
+		"t": "text.tex.latex source.lua support.function.any-method.lua"
+	},
+	{
+		"c": "(",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.begin.lua"
+	},
+	{
+		"c": "luatex",
+		"t": "text.tex.latex source.lua string.quoted.double.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.end.lua"
+	},
+	{
+		"c": ")) ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "do",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "if",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "string.match",
+		"t": "text.tex.latex source.lua support.function.library.lua"
+	},
+	{
+		"c": "(",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "i",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ",",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.begin.lua"
+	},
+	{
+		"c": "^U",
+		"t": "text.tex.latex source.lua string.quoted.double.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.end.lua"
+	},
+	{
+		"c": ") ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "then",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": "      ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "if",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "not",
+		"t": "text.tex.latex source.lua keyword.operator.lua"
+	},
+	{
+		"c": " ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "string.match",
+		"t": "text.tex.latex source.lua support.function.library.lua"
+	},
+	{
+		"c": "(",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "i",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ",",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.begin.lua"
+	},
+	{
+		"c": "^Uchar$",
+		"t": "text.tex.latex source.lua string.quoted.double.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.end.lua"
+	},
+	{
+		"c": ") ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "then",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": "        ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "table.insert",
+		"t": "text.tex.latex source.lua support.function.library.lua"
+	},
+	{
+		"c": "(",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "t",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ",",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "i",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ")",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "      ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": "    ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "end",
+		"t": "text.tex.latex source.lua keyword.control.lua"
+	},
+	{
+		"c": "  ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "tex",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ".",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "enableprimitives",
+		"t": "text.tex.latex source.lua support.function.any-method.lua"
+	},
+	{
+		"c": "(",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.begin.lua"
+	},
+	{
+		"c": "\"",
+		"t": "text.tex.latex source.lua string.quoted.double.lua punctuation.definition.string.end.lua"
+	},
+	{
+		"c": ", ",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "t",
+		"t": "text.tex.latex source.lua variable.other.lua"
+	},
+	{
+		"c": ")",
+		"t": "text.tex.latex source.lua"
+	},
+	{
+		"c": "}",
+		"t": "text.tex.latex punctuation.definition.arguments.end.latex"
 	}
 ]


### PR DESCRIPTION
Consider

```tex
\directlua{
  local i
  local t = { }
  for _,i in pairs(tex.extraprimitives("luatex")) do
    if string.match(i,"^U") then
      if not string.match(i,"^Uchar$") then
        table.insert(t,i)
      end
    end
  end
  tex.enableprimitives("", t)
}
```

When `luaexec{` is encountered, the following lines are matched against the Lua grammar until the Lua grammar does not match anything. At that time, control is given back to the LaTeX grammar. If the end pattern `}` is matched, the control stays in the LaTeX grammar, if not control is handed back to the Lua grammar. Here, the Lua grammar does not capture curly braces, hence the first closing `}`, appearing in `local t = { }` is considered by the LaTeX grammar as the end pattern of the group.

This PR is an attempt to match the braces inside the LaTeX grammar.


Close #117.