### PR TITLE
Updating regex for biblatex citation macros

### DIFF
--- a/src/LaTeX.tmLanguage.base.yaml
+++ b/src/LaTeX.tmLanguage.base.yaml
@@ -548,7 +548,7 @@ repository:
         - include: text.tex#braces
 
   citation-macro:
-    begin: ((\\)(?:[aA]uto|foot|full|no|ref|short|[tT]ext|[pP]aren|[sS]mart)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title)?[ANP]*\*?)((?:(?:\([^\)]*\)){0,2}(?:\[[^\]]*\]){0,2}\{[\p{Alphabetic}\p{Number}_:.-]*\})*)(<[^\]<>]*>)?((?:\[[^\]]*\])*)(\{)
+    begin: ((\\)(?:[aA]uto|foot|full|footfull|no|ref|short|[tT]ext|[pP]aren|[sS]mart|[fFpP]vol|vol)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title|url|date)?[ANP]*\*?)((?:(?:\([^\)]*\)){0,2}(?:\[[^\]]*\]){0,2}\{[\p{Alphabetic}\p{Number}_:.-]*\})*)(<[^\]<>]*>)?((?:\[[^\]]*\])*)(\{)
     captures:
       '1':
         name: keyword.control.cite.latex

--- a/syntaxes/DocTeX.tmLanguage.json
+++ b/syntaxes/DocTeX.tmLanguage.json
@@ -3398,7 +3398,7 @@
             ]
         },
         "citation-macro": {
-            "begin": "((\\\\)(?:[aA]uto|foot|full|no|ref|short|[tT]ext|[pP]aren|[sS]mart)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title)?[ANP]*\\*?)((?:(?:\\([^\\)]*\\)){0,2}(?:\\[[^\\]]*\\]){0,2}\\{[\\p{Alphabetic}\\p{Number}_:.-]*\\})*)(<[^\\]<>]*>)?((?:\\[[^\\]]*\\])*)(\\{)",
+            "begin": "((\\\\)(?:[aA]uto|foot|full|footfull|no|ref|short|[tT]ext|[pP]aren|[sS]mart|[fFpP]vol|vol)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title|url|date)?[ANP]*\\*?)((?:(?:\\([^\\)]*\\)){0,2}(?:\\[[^\\]]*\\]){0,2}\\{[\\p{Alphabetic}\\p{Number}_:.-]*\\})*)(<[^\\]<>]*>)?((?:\\[[^\\]]*\\])*)(\\{)",
             "captures": {
                 "1": {
                     "name": "keyword.control.cite.latex"

--- a/syntaxes/LaTeX.tmLanguage.json
+++ b/syntaxes/LaTeX.tmLanguage.json
@@ -3301,7 +3301,7 @@
             ]
         },
         "citation-macro": {
-            "begin": "((\\\\)(?:[aA]uto|foot|full|no|ref|short|[tT]ext|[pP]aren|[sS]mart)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title)?[ANP]*\\*?)((?:(?:\\([^\\)]*\\)){0,2}(?:\\[[^\\]]*\\]){0,2}\\{[\\p{Alphabetic}\\p{Number}_:.-]*\\})*)(<[^\\]<>]*>)?((?:\\[[^\\]]*\\])*)(\\{)",
+            "begin": "((\\\\)(?:[aA]uto|foot|full|footfull|no|ref|short|[tT]ext|[pP]aren|[sS]mart|[fFpP]vol|vol)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title|url|date)?[ANP]*\\*?)((?:(?:\\([^\\)]*\\)){0,2}(?:\\[[^\\]]*\\]){0,2}\\{[\\p{Alphabetic}\\p{Number}_:.-]*\\})*)(<[^\\]<>]*>)?((?:\\[[^\\]]*\\])*)(\\{)",
             "captures": {
                 "1": {
                     "name": "keyword.control.cite.latex"


### PR DESCRIPTION
I recently updated my Beamer template which cites paper as a footnote, and I notice for `\footfullcite` LaTeX Workshop cannot recognize the token after the macro as `constant.other.reference.citation.latex`. So this PR adds support for this citation macro, along with several other macros in https://tug.ctan.org/info/biblatex-cheatsheet/biblatex-cheatsheet.pdf, including

- `\footfullcite`
- `\volcite`, `\fvolcite`, `\pvolcite`
- `\citeurl`, `\citedate`

I only modified `LaTeX.tmLanguage.base.yaml`, the changes in jsons are generated by running `npm run test`, and the logs are pasted as follows:

```bash
> vscode-latex-basics@1.16.0 test
> npm run build-latex && node ./test/runTest.js


> vscode-latex-basics@1.16.0 build-latex
> node ./build/all.mjs build-latex

Generating BibTeX-style.tmLanguage.json from src/
Generating Bibtex.tmLanguage.json from src/
Generating DocTeX.tmLanguage.json from src/
Generating JLweave.tmLanguage.json from src/
Generating Pweave.tmLanguage.json from src/
Generating RSweave.tmLanguage.json from src/
Generating TeX.tmLanguage.json from src/
Generating LaTeX.tmLanguage from src/
Generating DocTeX.tmLanguage from src/
✔ Validated version: 1.108.0
✔ Found at https://update.code.visualstudio.com/1.108.0/darwin-arm64/stable?released=true
✔ Downloaded VS Code into /Users/sch59/Documents/vscode-latex-basics/.vscode-test/vscode-darwin-arm64-1.108.0
[main 2026-01-12T17:53:26.419Z] update#setState disabled
[main 2026-01-12T17:53:26.420Z] update#ctor - updates are disabled by the environment
Started initializing default profile extensions in extensions installation folder. file:///Users/sch59/Documents/vscode-latex-basics/.vscode-test/extensions
Started local extension host with pid 36503.
Completed initializing default profile extensions in extensions installation folder. file:///Users/sch59/Documents/vscode-latex-basics/.vscode-test/extensions
Loading development extension at /Users/sch59/Documents/vscode-latex-basics
MCP Registry configured: https://api.mcp.github.com
Settings Sync: Account status changed from uninitialized to unavailable

  colorization
    ✔ 33-wordref.tex (955ms)
    ✔ basic-commands.tex (423ms)
    ✔ basic-envs.tex (388ms)
    ✔ basics.dtx (291ms)
    ✔ beamer.tex (284ms)
    ✔ cite.tex (160ms)
    ✔ code-asy.tex (97ms)
    ✔ code-cpp.tex (640ms)
    ✔ code-css.tex (201ms)
    ✔ code-html.tex (141ms)
    ✔ code-java.tex (180ms)
    ✔ code-jl.tex (255ms)
    ✔ code-js.tex (349ms)
    ✔ code-lua.tex (262ms)
    ✔ code-py.tex (241ms)
    ✔ code-rb.tex (104ms)
    ✔ code-ts.tex (352ms)
    ✔ code-xml.tex (84ms)
    ✔ code-yaml.tex (146ms)
    ✔ hyperref-cmds.tex (175ms)
    ✔ iffalse.tex (227ms)
    ✔ injected.md (278ms)
    ✔ math-envs.tex (1801ms)
    ✔ maths-inline.tex (193ms)
    ✔ minted.tex (153ms)
    ✔ robust-externalize.tex (578ms)
    ✔ skeleton.dtx (424ms)
    ✔ songs.tex (390ms)
    ✔ subeqn.dtx (943ms)
    ✔ terminal.tex (111ms)
    ✔ test.bib (601ms)
    ✔ tikz.tex (153ms)
  32 passing (12s)
[main 2026-01-12T17:53:50.258Z] Extension host with pid 36503 exited with code: 0, signal: unknown.
Exit code:   0
```